### PR TITLE
*: Add rewrite functionality of SubjectAccessReview requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.10-alpine AS build
+FROM golang:1.11-alpine AS build
 RUN apk add --update make
 WORKDIR /go/src/github.com/brancz/kube-rbac-proxy
 COPY . .
 RUN make build
 
-FROM alpine:3.7
+FROM alpine:3.8
 COPY --from=build /go/src/github.com/brancz/kube-rbac-proxy/_output/linux/amd64/kube-rbac-proxy .
 ENTRYPOINT ["./kube-rbac-proxy"]
 EXPOSE 8080

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ container:
 curl-container:
 	docker build -f ./examples/example-client/Dockerfile -t quay.io/brancz/krp-curl:v0.0.1 .
 
+run-curl-container:
+	@echo 'Example: curl -v -s -k -H "Authorization: Bearer `cat /var/run/secrets/kubernetes.io/serviceaccount/token`" https://kube-rbac-proxy.default.svc:8443/metrics'
+	kubectl run -i -t krp-curl --image=quay.io/brancz/krp-curl:v0.0.1 --restart=Never --command -- /bin/sh
+
 grpcc-container:
 	docker build -f ./examples/grpcc/Dockerfile -t mumoshu/grpcc:v0.0.1 .
 

--- a/examples/rewrites/deployment.yaml
+++ b/examples/rewrites/deployment.yaml
@@ -7,7 +7,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kube-rbac-proxy
-  namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -30,12 +29,6 @@ rules:
   resources:
   - subjectaccessreviews
   verbs: ["create"]
-- apiGroups: ["", "apps", "extensions", "rbac.authorization.k8s.io"]
-  resources: ["*"]
-  verbs: ["*"]
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: ["get", "list"]
 ---
 apiVersion: v1
 kind: Service
@@ -46,10 +39,26 @@ metadata:
 spec:
   ports:
   - name: https
-    port: 8444
+    port: 8443
     targetPort: https
   selector:
     app: kube-rbac-proxy
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-rbac-proxy
+data:
+  resource-attributes.yaml: |+
+    authorization:
+      rewrites:
+        byQueryParameter:
+          name: "namespace"
+      resourceAttributes:
+        apiVersion: v1
+        resource: namespace
+        subresource: metrics
+        namespace: "{{ .Value }}"
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -62,25 +71,25 @@ spec:
       labels:
         app: kube-rbac-proxy
     spec:
-      # {BEGIN} for minikube development only if OIDC provider is deployed in minikube itself ie. dex
-      hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
-      # {END}
       serviceAccountName: kube-rbac-proxy
       containers:
       - name: kube-rbac-proxy
         image: quay.io/brancz/kube-rbac-proxy:v0.3.1
         args:
-        - "--insecure-listen-address=0.0.0.0:8444"
-        - "--upstream=http://127.0.0.1:8081/"
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://localhost:8080/"
+        - "--resource-attributes-file=/etc/kube-rbac-proxy/resource-attributes.yaml"
         - "--logtostderr=true"
         - "--v=10"
-        - "--oidc-issuer={ISSUER}"
-        - "--oidc-clientID={CLIENT_ID}"
         ports:
-        - containerPort: 8444
+        - containerPort: 8443
           name: https
-      - name: prometheus-example-app
-        image: quay.io/brancz/prometheus-example-app:v0.1.0
-        args:
-        - "--bind=127.0.0.1:8081"
+        volumeMounts:
+        - name: config
+          mountPath: /etc/kube-rbac-proxy
+      - name: printserver
+        image: quay.io/brancz/printserver:v0.0.1
+      volumes:
+      - name: config
+        configMap:
+          name: kube-rbac-proxy

--- a/examples/rewrites/rbac.yaml
+++ b/examples/rewrites/rbac.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: node-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: namespace-metrics
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: namespace-metrics
+rules:
+- apiGroups: [""]
+  resources:
+  - namespace/metrics
+  verbs: ["get"]

--- a/examples/rewrites/resource-attributes.yaml
+++ b/examples/rewrites/resource-attributes.yaml
@@ -1,0 +1,9 @@
+authorization:
+  rewrites:
+    byQueryParameter:
+      name: "namespace"
+  resourceAttributes:
+    apiVersion: v1
+    resource: node
+    subresource: metrics
+    namespace: "{{ .Value }}"

--- a/pkg/authz/auth.go
+++ b/pkg/authz/auth.go
@@ -27,8 +27,21 @@ import (
 
 // Config holds configuration enabling request authorization
 type Config struct {
-	ResourceAttributes     *ResourceAttributes
-	ResourceAttributesFile string
+	Rewrites               *SubjectAccessReviewRewrites `json:"rewrites,omitempty"`
+	ResourceAttributes     *ResourceAttributes          `json:"resourceAttributes,omitempty"`
+	ResourceAttributesFile string                       `json:"-"`
+}
+
+// SubjectAccessReviewRewrites describes how SubjectAccessReview may be
+// rewritten on a given request.
+type SubjectAccessReviewRewrites struct {
+	ByQueryParameter *QueryParameterRewriteConfig `json:"byQueryParameter,omitempty"`
+}
+
+// QueryParameterRewriteConfig describes which HTTP URL query parameter is to
+// be used to rewrite a SubjectAccessReview on a given request.
+type QueryParameterRewriteConfig struct {
+	Name string `json:"name,omitempty"`
 }
 
 // ResourceAttributes describes attributes available for resource request authorization


### PR DESCRIPTION
This PR adds rewrite functionality based on query parameters of an URL. For example, when configured to the `namespace` query parameter then the value passed in a request can be templated in the SubjectAccessReview done against the Kubernetes API. This allows SubjectAccessReviews to be dependent on the parameter passed. For example this can be used with the [prom-label-proxy](https://github.com/openshift/prom-label-proxy) to validate that a requesting user (or Prometheus server) is allowed to access metrics for a certain namespace, and if so it is passed onto the label proxy through, which then enforces the PromQL query to have the respective namespace in the query.

If a rewrite by parameter is configured but no parameter is given, then the request is returned as a `BadRequest`.

@s-urbaniak @metalmatze