### PR TITLE
Remove hardcoded amd64 to allow multi-arch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ RUN make build
 
 FROM alpine:3.8
 RUN apk add -U --no-cache ca-certificates && rm -rf /var/cache/apk/*
-COPY --from=build /go/src/github.com/brancz/kube-rbac-proxy/_output/linux/amd64/kube-rbac-proxy .
+COPY --from=build /go/src/github.com/brancz/kube-rbac-proxy/_output/linux/$(go env ARCH)/kube-rbac-proxy .
 ENTRYPOINT ["./kube-rbac-proxy"]
 EXPOSE 8080


### PR DESCRIPTION
Same as this: https://github.com/openshift/kube-rbac-proxy/pull/4