### PR TITLE
Check errors and log them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM golang:1.11-alpine AS build
 RUN apk add --update make
 WORKDIR /go/src/github.com/brancz/kube-rbac-proxy
 COPY . .
-RUN make build
+RUN make build && cp /go/src/github.com/brancz/kube-rbac-proxy/_output/linux/$(go env GOARCH)/kube-rbac-proxy /usr/local/bin
 
 FROM alpine:3.8
 RUN apk add -U --no-cache ca-certificates && rm -rf /var/cache/apk/*
-COPY --from=build /go/src/github.com/brancz/kube-rbac-proxy/_output/linux/$(go env GOARCH)/kube-rbac-proxy .
+COPY --from=build /usr/local/bin/kube-rbac-proxy .
 ENTRYPOINT ["./kube-rbac-proxy"]
 EXPOSE 8080


### PR DESCRIPTION
When starting a server we should check their return values and log them.
Additionally, we should think about using something like `run.Group` to terminate all goroutines if one server fails.

/cc @brancz @squat @mxinden