### PR TITLE
Add support for x-forwarded-for header

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,36 +28,37 @@ All command line flags:
 ```txt
 $ kube-rbac-proxy -h
 Usage of _output/linux/amd64/kube-rbac-proxy:
-      --alsologtostderr                             log to standard error as well as files
-      --auth-header-fields-enabled                  When set to true, kube-rbac-proxy adds auth-related fields to the headers of http requests sent to the upstream
-      --auth-header-groups-field-name string        The name of the field inside a http(2) request header to tell the upstream server about the user's groups (default "x-remote-groups")
-      --auth-header-groups-field-separator string   The separator string used for concatenating multiple group names in a groups header field's value (default "|")
-      --auth-header-user-field-name string          The name of the field inside a http(2) request header to tell the upstream server about the user's name (default "x-remote-user")
-      --client-ca-file string                       If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.
-      --config-file string                          Configuration file to configure kube-rbac-proxy.
-      --insecure-listen-address string              The address the kube-rbac-proxy HTTP server should listen on.
-      --kubeconfig string                           Path to a kubeconfig file, specifying how to connect to the API server. If unset, in-cluster configuration will be used
-      --log_backtrace_at traceLocation              when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                              If non-empty, write log files in this directory
-      --logtostderr                                 log to standard error instead of files
-      --oidc-ca-file string                         If set, the OpenID server's certificate will be verified by one of the authorities in the oidc-ca-file, otherwise the host's root CA set will be used.
-      --oidc-clientID string                        The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.
-      --oidc-groups-claim string                    Identifier of groups in JWT claim, by default set to 'groups' (default "groups")
-      --oidc-groups-prefix string                   If provided, all groups will be prefixed with this value to prevent conflicts with other authentication strategies.
-      --oidc-issuer string                          The URL of the OpenID issuer, only HTTPS scheme will be accepted. If set, it will be used to verify the OIDC JSON Web Token (JWT).
-      --oidc-sign-alg stringArray                   Supported signing algorithms, default RS256 (default [RS256])
-      --oidc-username-claim string                  Identifier of the user in JWT claim, by default set to 'email' (default "email")
-      --secure-listen-address string                The address the kube-rbac-proxy HTTPs server should listen on.
-      --stderrthreshold severity                    logs at or above this threshold go to stderr (default 2)
-      --tls-cert-file string                        File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert)
-      --tls-cipher-suites strings                   Comma-separated list of cipher suites for the server. Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants). If omitted, the default Go cipher suites will be used
-      --tls-min-version string                      Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants. (default "VersionTLS12")
-      --tls-private-key-file string                 File containing the default x509 private key matching --tls-cert-file.
-      --upstream string                             The upstream URL to proxy to once requests have successfully been authenticated and authorized.
-      --upstream-ca-file string                     The CA the upstream uses for TLS connection. This is required when the upstream uses TLS and its own CA certificate
-      --upstream-force-h2c                          Force h2c to communiate with the upstream. This is required when the upstream speaks h2c(http/2 cleartext - insecure variant of http/2) only. For example, go-grpc server in the insecure mode, such as helm's tiller w/o TLS, speaks h2c only
-  -v, --v Level                                     log level for V logs
-      --vmodule moduleSpec                          comma-separated list of pattern=N settings for file-filtered logging
+      --alsologtostderr                              log to standard error as well as files
+      --auth-header-fields-enabled                   When set to true, kube-rbac-proxy adds auth-related fields to the headers of http requests sent to the upstream
+      --auth-header-forwardedfor-field-name string   The name of the field inside a http(2) request header to tell the upstream server about the originating IP address of the client connecting through the proxy (default "x-forwarded-for")
+      --auth-header-groups-field-name string         The name of the field inside a http(2) request header to tell the upstream server about the user's groups (default "x-remote-groups")
+      --auth-header-groups-field-separator string    The separator string used for concatenating multiple group names in a groups header field's value (default "|")
+      --auth-header-user-field-name string           The name of the field inside a http(2) request header to tell the upstream server about the user's name (default "x-remote-user")
+      --client-ca-file string                        If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.
+      --config-file string                           Configuration file to configure kube-rbac-proxy.
+      --insecure-listen-address string               The address the kube-rbac-proxy HTTP server should listen on.
+      --kubeconfig string                            Path to a kubeconfig file, specifying how to connect to the API server. If unset, in-cluster configuration will be used
+      --log_backtrace_at traceLocation               when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                               If non-empty, write log files in this directory
+      --logtostderr                                  log to standard error instead of files
+      --oidc-ca-file string                          If set, the OpenID server's certificate will be verified by one of the authorities in the oidc-ca-file, otherwise the host's root CA set will be used.
+      --oidc-clientID string                         The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.
+      --oidc-groups-claim string                     Identifier of groups in JWT claim, by default set to 'groups' (default "groups")
+      --oidc-groups-prefix string                    If provided, all groups will be prefixed with this value to prevent conflicts with other authentication strategies.
+      --oidc-issuer string                           The URL of the OpenID issuer, only HTTPS scheme will be accepted. If set, it will be used to verify the OIDC JSON Web Token (JWT).
+      --oidc-sign-alg stringArray                    Supported signing algorithms, default RS256 (default [RS256])
+      --oidc-username-claim string                   Identifier of the user in JWT claim, by default set to 'email' (default "email")
+      --secure-listen-address string                 The address the kube-rbac-proxy HTTPs server should listen on.
+      --stderrthreshold severity                     logs at or above this threshold go to stderr (default 2)
+      --tls-cert-file string                         File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert)
+      --tls-cipher-suites strings                    Comma-separated list of cipher suites for the server. Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants). If omitted, the default Go cipher suites will be used
+      --tls-min-version string                       Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants. (default "VersionTLS12")
+      --tls-private-key-file string                  File containing the default x509 private key matching --tls-cert-file.
+      --upstream string                              The upstream URL to proxy to once requests have successfully been authenticated and authorized.
+      --upstream-ca-file string                      The CA the upstream uses for TLS connection. This is required when the upstream uses TLS and its own CA certificate
+      --upstream-force-h2c                           Force h2c to communiate with the upstream. This is required when the upstream speaks h2c(http/2 cleartext - insecure variant of http/2) only. For example, go-grpc server in the insecure mode, such as helm's tiller w/o TLS, speaks h2c only
+  -v, --v Level                                      log level for V logs
+      --vmodule moduleSpec                           comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 ## Why?

--- a/main.go
+++ b/main.go
@@ -352,7 +352,23 @@ func initKubeConfig(kcLocation string) *rest.Config {
 	return kubeConfig
 }
 
+// getOutboundIP returns IP address of the interface used to communicate with upstreamHost
 func getOutboundIP(upstreamHost string) (string, error) {
+	// When net.Dial is used with UDP protocol, all internal data structures are populated
+	// with actual information, but no communication is performed yet (no TCP handshake).
+	// This is the most reliable way to get address of the interface, what will be used.
+	//
+	// There are alternative ways how to get IP address of a local interface.
+	// But none of them reliably provide address of the interface which will actually be
+	// used to talk to upstreamHost:
+	//
+	//   hostname, _ := os.Hostname()
+	//   net.LookupHost(hostname)
+	//
+	//   ifaces, _ := net.Interfaces()
+	//   for _, i := range ifaces {
+	//   	...
+	//   }
 	conn, err := net.Dial("udp", upstreamHost)
 	if err != nil {
 		return "", err

--- a/pkg/authn/config.go
+++ b/pkg/authn/config.go
@@ -28,6 +28,9 @@ type AuthnHeaderConfig struct {
 	GroupsFieldName string
 	// The separator string used for concatenating multiple group names in a groups header field's value
 	GroupSeparator string
+	// Corresponds to the name of the field inside a http(2) request header
+	// to tell the upstream server about the proxy server(s) the request was forwarded for
+	XForwardedFor string
 }
 
 // AuthnConfig holds all configurations related to authentication options


### PR DESCRIPTION
This header is commonly used by software that can be configured
to a _behind a proxy_ mode. Requests not only have to present
specific http headers, request also have to come from a range
of specific addresses, which makes header spoofing attacks
more difficult.