### PR TITLE
Fix proxy test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,10 @@ grpcc-container:
 
 test:
 	@echo ">> running all tests"
+	# install test dependencies
 	@go test -i $(PKGS)
+	# run the tests
+	@go test  $(PKGS)
 
 generate: embedmd
 	@echo ">> generating examples"

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package proxy
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -127,11 +128,11 @@ func fakeJWTRequest(method, path, token string) *http.Request {
 
 func fakeOIDCAuthenticator(t *testing.T, fakeUser *user.DefaultInfo) authenticator.Request {
 
-	auth := bearertoken.New(authenticator.TokenFunc(func(token string) (user.Info, bool, error) {
+	auth := bearertoken.New(authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
 		if token != "VALID" {
 			return nil, false, nil
 		}
-		return fakeUser, true, nil
+		return &authenticator.Response{User: fakeUser}, true, nil
 	}))
 	return auth
 }


### PR DESCRIPTION
apiserver.authenticator in [kube 1.11](https://github.com/kubernetes/kubernetes/blob/release-1.11/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/interfaces.go#L47)
vs
[kube 1.13](https://github.com/kubernetes/kubernetes/blob/release-1.13/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/interfaces.go#L46)

Which is what's now in glide.yaml.

make test output:
```
>> running all tests
# install test dependencies
# run the tests
?   	github.com/brancz/kube-rbac-proxy	[no test files]
?   	github.com/brancz/kube-rbac-proxy/pkg/authn	[no test files]
?   	github.com/brancz/kube-rbac-proxy/pkg/authz	[no test files]
ok  	github.com/brancz/kube-rbac-proxy/pkg/proxy	0.019s
```