### PR TITLE
Create basic end to end tests with kubetest framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - '1.11.x'
+  - '1.12.x'
 
 go_import_path: github.com/brancz/kube-rbac-proxy
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: go
+
+go:
+  - '1.11.x'
+
+go_import_path: github.com/brancz/kube-rbac-proxy
+
+services:
+  - docker
+
+jobs:
+  include:
+    - stage: Integration Tests
+      before_script:
+        - curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/0.2.1/kind-linux-amd64 && chmod +x kind && sudo mv kind /usr/local/bin/
+        - kind create cluster
+        - export KUBECONFIG="$(kind get kubeconfig-path)"
+      script: make test-e2e

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,7 @@ jobs:
         - curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/0.2.1/kind-linux-amd64 && chmod +x kind && sudo mv kind /usr/local/bin/
         - kind create cluster
         - export KUBECONFIG="$(kind get kubeconfig-path)"
-      script: make test-e2e
+      script:
+        - VERSION=local make container
+        - kind load docker-image quay.io/brancz/kube-rbac-proxy:local
+        - make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ test:
 	# run the tests
 	@go test  $(PKGS)
 
+test-e2e:
+	go test -timeout 55m -v ./test/e2e/ $(TEST_RUN_ARGS) --kubeconfig=$(KUBECONFIG)
+
 generate: embedmd
 	@echo ">> generating examples"
 	@./scripts/generate-examples.sh

--- a/test/e2e/basics.go
+++ b/test/e2e/basics.go
@@ -1,0 +1,105 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/brancz/kube-rbac-proxy/test/kubetest"
+	"k8s.io/client-go/kubernetes"
+)
+
+func testBasics(s *kubetest.Suite) kubetest.TestSuite {
+	return func(t *testing.T) {
+		command := `curl -v -s -k --fail -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" https://kube-rbac-proxy.default.svc.cluster.local:8443/metrics`
+
+		kubetest.Scenario{
+			Name: "NoRBAC",
+			Description: `
+				As a client without any RBAC rule access,
+				I fail with my request
+			`,
+
+			Given: kubetest.Setups(
+				kubetest.CreatedManifests(
+					s.KubeClient,
+					"basics/clusterRole.yaml",
+					"basics/clusterRoleBinding.yaml",
+					"basics/deployment.yaml",
+					"basics/service.yaml",
+					"basics/serviceAccount.yaml",
+				),
+			),
+			When: kubetest.Conditions(
+				kubetest.PodsAreReady(
+					s.KubeClient,
+					1,
+					"app=kube-rbac-proxy",
+				),
+			),
+			Then: kubetest.Checks(
+				ClientFails(
+					s.KubeClient,
+					command,
+				),
+			),
+		}.Run(t)
+
+		kubetest.Scenario{
+			Name: "WithRBAC",
+			Description: `
+				As a client with the correct RBAC rules,
+				I succeed with my request
+			`,
+
+			Given: kubetest.Setups(
+				kubetest.CreatedManifests(
+					s.KubeClient,
+					"basics/clusterRole.yaml",
+					"basics/clusterRoleBinding.yaml",
+					"basics/deployment.yaml",
+					"basics/service.yaml",
+					"basics/serviceAccount.yaml",
+					// This adds the clients cluster role to succeed
+					"basics/clusterRole-client.yaml",
+					"basics/clusterRoleBinding-client.yaml",
+				),
+			),
+			When: kubetest.Conditions(
+				kubetest.PodsAreReady(
+					s.KubeClient,
+					1,
+					"app=kube-rbac-proxy",
+				),
+			),
+			Then: kubetest.Checks(
+				ClientSucceeds(
+					s.KubeClient,
+					command,
+				),
+			),
+		}.Run(t)
+	}
+}
+
+func ClientSucceeds(client kubernetes.Interface, command string) kubetest.Check {
+	return func(ctx *kubetest.ScenarioContext) error {
+		return kubetest.RunSucceeds(
+			client,
+			"alpine",
+			"kube-rbac-proxy-client",
+			[]string{"/bin/sh", "-c", "apk add -U curl && " + command},
+			&kubetest.RunOptions{ServiceAccount: "default"},
+		)(ctx)
+	}
+}
+
+func ClientFails(client kubernetes.Interface, command string) kubetest.Check {
+	return func(ctx *kubetest.ScenarioContext) error {
+		return kubetest.RunFails(
+			client,
+			"alpine",
+			"kube-rbac-proxy-client",
+			[]string{"/bin/sh", "-c", "apk add -U curl && " + command},
+			&kubetest.RunOptions{ServiceAccount: "default"},
+		)(ctx)
+	}
+}

--- a/test/e2e/basics/clusterRole-client.yaml
+++ b/test/e2e/basics/clusterRole-client.yaml
@@ -1,0 +1,7 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: metrics
+rules:
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]

--- a/test/e2e/basics/clusterRole.yaml
+++ b/test/e2e/basics/clusterRole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-rbac-proxy
+  namespace: default
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources:
+      - tokenreviews
+    verbs: ["create"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources:
+      - subjectaccessreviews
+    verbs: ["create"]

--- a/test/e2e/basics/clusterRoleBinding-client.yaml
+++ b/test/e2e/basics/clusterRoleBinding-client.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metrics
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: default

--- a/test/e2e/basics/clusterRoleBinding.yaml
+++ b/test/e2e/basics/clusterRoleBinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-rbac-proxy
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-rbac-proxy
+subjects:
+  - kind: ServiceAccount
+    name: kube-rbac-proxy
+    namespace: default

--- a/test/e2e/basics/deployment.yaml
+++ b/test/e2e/basics/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-rbac-proxy
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-rbac-proxy
+  template:
+    metadata:
+      labels:
+        app: kube-rbac-proxy
+    spec:
+      serviceAccountName: kube-rbac-proxy
+      containers:
+        - name: kube-rbac-proxy
+          image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+          args:
+            - "--secure-listen-address=0.0.0.0:8443"
+            - "--upstream=http://127.0.0.1:8081/"
+            - "--logtostderr=true"
+            - "--v=10"
+          ports:
+            - containerPort: 8443
+              name: https
+        - name: prometheus-example-app
+          image: quay.io/brancz/prometheus-example-app:v0.1.0
+          args:
+            - "--bind=127.0.0.1:8081"

--- a/test/e2e/basics/deployment.yaml
+++ b/test/e2e/basics/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: kube-rbac-proxy
       containers:
         - name: kube-rbac-proxy
-          image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+          image: quay.io/brancz/kube-rbac-proxy:local
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8081/"

--- a/test/e2e/basics/service.yaml
+++ b/test/e2e/basics/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-rbac-proxy
+  name: kube-rbac-proxy
+  namespace: default
+spec:
+  ports:
+    - name: https
+      port: 8443
+      targetPort: https
+  selector:
+    app: kube-rbac-proxy

--- a/test/e2e/basics/serviceAccount.yaml
+++ b/test/e2e/basics/serviceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-rbac-proxy
+  namespace: default

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,0 +1,42 @@
+package e2e
+
+import (
+	"flag"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/brancz/kube-rbac-proxy/test/kubetest"
+)
+
+// Sadly there's no way to pass Suite from TestMain to Test,
+// so we need this global instance
+var suite *kubetest.Suite
+
+// TestMain adds the kubeconfig flag to our tests
+func TestMain(m *testing.M) {
+	kubeconfig := flag.String(
+		"kubeconfig",
+		"",
+		"path to kubeconfig",
+	)
+	flag.Parse()
+
+	var err error
+	suite, err = kubetest.NewSuiteFromKubeconfig(*kubeconfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	os.Exit(m.Run())
+}
+
+func Test(t *testing.T) {
+	tests := map[string]kubetest.TestSuite{
+		"Basics": testBasics(suite),
+	}
+
+	for name, tc := range tests {
+		t.Run(name, tc)
+	}
+}

--- a/test/kubetest/kubernetes.go
+++ b/test/kubetest/kubernetes.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -322,7 +321,10 @@ func CreateNamespace(client kubernetes.Interface, name string) error {
 			Name: name,
 		},
 	})
-	return errors.Wrap(err, fmt.Sprintf("failed to create namespace with name %v", name))
+	if err != nil {
+		return fmt.Errorf("failed to create namespace with name %v", name)
+	}
+	return nil
 }
 
 func DeleteNamespace(client kubernetes.Interface, name string) error {

--- a/test/kubetest/kubernetes.go
+++ b/test/kubetest/kubernetes.go
@@ -1,0 +1,330 @@
+package kubetest
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kubeyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/kubernetes"
+)
+
+func CreatedManifests(client kubernetes.Interface, paths ...string) Setup {
+	return func(ctx *ScenarioContext) error {
+		for _, path := range paths {
+			content, err := ioutil.ReadFile(path)
+			if err != nil {
+				return err
+			}
+
+			if len(content) == 0 {
+				return fmt.Errorf("manifest has no content: %s", path)
+			}
+
+			var meta metav1.TypeMeta
+			if err = yaml.Unmarshal(content, &meta); err != nil {
+				return err
+			}
+
+			// TODO: This needs to be more generic!
+
+			kind := strings.ToLower(meta.Kind)
+			switch kind {
+			case "clusterrole":
+				if err := createClusterRole(client, ctx, content); err != nil {
+					return err
+				}
+			case "clusterrolebinding":
+				if err := createClusterRoleBinding(client, ctx, content); err != nil {
+					return err
+				}
+			case "deployment":
+				if err := createDeployment(client, ctx, content); err != nil {
+					return err
+				}
+			case "service":
+				if err := createService(client, ctx, content); err != nil {
+					return err
+				}
+			case "serviceaccount":
+				if err := createServiceAccount(client, ctx, content); err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("unable to unmarshal manifest with unknown kind: %s", kind)
+			}
+		}
+		return nil
+	}
+}
+
+func createClusterRole(client kubernetes.Interface, ctx *ScenarioContext, content []byte) error {
+	r := bytes.NewReader(content)
+
+	var cr *rbacv1.ClusterRole
+	if err := kubeyaml.NewYAMLOrJSONDecoder(r, r.Len()).Decode(&cr); err != nil {
+		return err
+	}
+
+	_, err := client.RbacV1().ClusterRoles().Create(cr)
+
+	ctx.AddFinalizer(func() error {
+		return client.RbacV1().ClusterRoles().Delete(cr.Name, nil)
+	})
+
+	return err
+}
+
+func createClusterRoleBinding(client kubernetes.Interface, ctx *ScenarioContext, content []byte) error {
+	r := bytes.NewReader(content)
+
+	var crb *rbacv1.ClusterRoleBinding
+	if err := kubeyaml.NewYAMLOrJSONDecoder(r, r.Len()).Decode(&crb); err != nil {
+		return err
+	}
+
+	_, err := client.RbacV1().ClusterRoleBindings().Create(crb)
+
+	ctx.AddFinalizer(func() error {
+		return client.RbacV1().ClusterRoleBindings().Delete(crb.Name, nil)
+	})
+
+	return err
+}
+
+func createDeployment(client kubernetes.Interface, ctx *ScenarioContext, content []byte) error {
+	r := bytes.NewReader(content)
+
+	var d appsv1.Deployment
+	if err := kubeyaml.NewYAMLOrJSONDecoder(r, r.Len()).Decode(&d); err != nil {
+		return err
+	}
+
+	d.Namespace = ctx.Namespace
+
+	_, err := client.AppsV1().Deployments(d.Namespace).Create(&d)
+
+	ctx.AddFinalizer(func() error {
+		return client.AppsV1().Deployments(d.Namespace).Delete(d.Name, nil)
+	})
+
+	return err
+}
+
+func createService(client kubernetes.Interface, ctx *ScenarioContext, content []byte) error {
+	r := bytes.NewReader(content)
+
+	var s *corev1.Service
+	if err := kubeyaml.NewYAMLOrJSONDecoder(r, r.Len()).Decode(&s); err != nil {
+		return err
+	}
+
+	s.Namespace = ctx.Namespace
+
+	_, err := client.CoreV1().Services(s.Namespace).Create(s)
+
+	ctx.AddFinalizer(func() error {
+		return client.CoreV1().Services(s.Namespace).Delete(s.Name, nil)
+	})
+
+	return err
+}
+
+func createServiceAccount(client kubernetes.Interface, ctx *ScenarioContext, content []byte) error {
+	r := bytes.NewReader(content)
+
+	var sa *corev1.ServiceAccount
+	if err := kubeyaml.NewYAMLOrJSONDecoder(r, r.Len()).Decode(&sa); err != nil {
+		return err
+	}
+
+	sa.Namespace = ctx.Namespace
+
+	_, err := client.CoreV1().ServiceAccounts(sa.Namespace).Create(sa)
+
+	ctx.AddFinalizer(func() error {
+		return client.CoreV1().ServiceAccounts(sa.Namespace).Delete(sa.Name, nil)
+	})
+
+	return err
+}
+
+// PodsAreReady waits for a number if replicas matching the given labels to be ready.
+// Returns a func directly (not Setup or Conditions) as it can be used in Given and When steps
+func PodsAreReady(client kubernetes.Interface, replicas int, labels string) func(*ScenarioContext) error {
+	return func(ctx *ScenarioContext) error {
+		return wait.Poll(time.Second, time.Minute, func() (bool, error) {
+			list, err := client.CoreV1().Pods(ctx.Namespace).List(metav1.ListOptions{
+				LabelSelector: labels,
+			})
+			if err != nil {
+				return false, fmt.Errorf("failed to list pods: %v", err)
+			}
+
+			runningAndReady := 0
+			for _, p := range list.Items {
+				isRunningAndReady, err := podRunningAndReady(p)
+				if err != nil {
+					return false, err
+				}
+
+				if isRunningAndReady {
+					runningAndReady++
+				}
+			}
+
+			if runningAndReady == replicas {
+				return true, nil
+			}
+			return false, nil
+		})
+	}
+}
+
+// podRunningAndReady returns whether a pod is running and each container has
+// passed it's ready state.
+func podRunningAndReady(pod corev1.Pod) (bool, error) {
+	switch pod.Status.Phase {
+	case corev1.PodFailed, corev1.PodSucceeded:
+		return false, fmt.Errorf("pod completed")
+	case corev1.PodRunning:
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type != corev1.PodReady {
+				continue
+			}
+			return cond.Status == corev1.ConditionTrue, nil
+		}
+		return false, fmt.Errorf("pod ready condition not found")
+	}
+	return false, nil
+}
+
+func Sleep(d time.Duration) Condition {
+	return func(ctx *ScenarioContext) error {
+		time.Sleep(d)
+		return nil
+	}
+}
+
+type RunOptions struct {
+	ServiceAccount string
+}
+
+func RunSucceeds(client kubernetes.Interface, image string, name string, command []string, opts *RunOptions) Check {
+	return func(ctx *ScenarioContext) error {
+		logs, err := run(client, ctx, image, name, command, opts)
+		if err != nil {
+			_, _ = fmt.Fprint(os.Stderr, string(logs))
+			return err
+		}
+		return nil
+	}
+}
+
+func RunFails(client kubernetes.Interface, image string, name string, command []string, opts *RunOptions) Check {
+	return func(ctx *ScenarioContext) error {
+		logs, err := run(client, ctx, image, name, command, opts)
+		if err == nil {
+			_, _ = fmt.Fprint(os.Stderr, string(logs))
+			return fmt.Errorf("expected run to fail")
+		}
+		if err != errRun {
+			return err
+		}
+		return nil
+	}
+}
+
+var errRun = fmt.Errorf("failed to run")
+
+// run the command and return the Check with the container's logs
+func run(client kubernetes.Interface, ctx *ScenarioContext, image string, name string, command []string, opts *RunOptions) ([]byte, error) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ctx.Namespace,
+			Labels: map[string]string{
+				"app": name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:    name,
+				Image:   image,
+				Command: command,
+			}},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+
+	if opts != nil {
+		pod.Spec.ServiceAccountName = opts.ServiceAccount
+	}
+
+	ctx.AddFinalizer(func() error {
+		return client.CoreV1().Pods(ctx.Namespace).Delete(pod.ObjectMeta.Name, nil)
+	})
+
+	_, err := client.CoreV1().Pods(ctx.Namespace).Create(pod)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pod: %v", err)
+	}
+
+	watch, err := client.CoreV1().Pods(ctx.Namespace).Watch(metav1.SingleObject(pod.ObjectMeta))
+	if err != nil {
+		return nil, fmt.Errorf("failed to watch pod: %v", err)
+	}
+
+	for event := range watch.ResultChan() {
+		pod := event.Object.(*corev1.Pod)
+		phase := pod.Status.Phase
+
+		if phase == corev1.PodFailed {
+			logs, _ := podLogs(client, ctx.Namespace, name, name)
+			return logs, errRun
+		}
+		if phase == corev1.PodSucceeded {
+			break
+		}
+	}
+
+	logs, _ := podLogs(client, ctx.Namespace, name, name)
+	return logs, nil
+}
+
+func podLogs(client kubernetes.Interface, namespace, pod, container string) ([]byte, error) {
+	rest := client.CoreV1().Pods(namespace).GetLogs(pod, &corev1.PodLogOptions{
+		Container: container,
+		Follow:    false,
+	})
+
+	stream, err := rest.Stream()
+	if err != nil {
+		return nil, err
+	}
+	return ioutil.ReadAll(stream)
+}
+
+func CreateNamespace(client kubernetes.Interface, name string) error {
+	_, err := client.CoreV1().Namespaces().Create(&v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	})
+	return errors.Wrap(err, fmt.Sprintf("failed to create namespace with name %v", name))
+}
+
+func DeleteNamespace(client kubernetes.Interface, name string) error {
+	return client.CoreV1().Namespaces().Delete(name, nil)
+}

--- a/test/kubetest/kubetest.go
+++ b/test/kubetest/kubetest.go
@@ -1,0 +1,154 @@
+package kubetest
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type Suite struct {
+	KubeClient kubernetes.Interface
+}
+
+func NewSuiteFromKubeconfig(path string) (*Suite, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", path)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Suite{KubeClient: client}, nil
+}
+
+type TestSuite func(t *testing.T)
+
+type Scenario struct {
+	KubeClient kubernetes.Interface
+
+	Name        string
+	Description string
+
+	Given Setup
+	When  Condition
+	Then  Check
+}
+
+type ScenarioContext struct {
+	Namespace string
+	Finalizer []Finalizer
+}
+
+func (ctx *ScenarioContext) AddFinalizer(f Finalizer) {
+	ctx.Finalizer = append(ctx.Finalizer, f)
+}
+
+type RunOpts func(ctx *ScenarioContext) *ScenarioContext
+
+func RandomNamespace(client kubernetes.Interface) RunOpts {
+	return func(ctx *ScenarioContext) *ScenarioContext {
+		ctx.Namespace = rand.String(8)
+
+		ctx.AddFinalizer(func() error {
+			return DeleteNamespace(client, ctx.Namespace)
+		})
+
+		if err := CreateNamespace(client, ctx.Namespace); err != nil {
+			panic(err)
+		}
+
+		return ctx
+	}
+}
+
+func Timeout(d time.Duration) RunOpts {
+	return func(ctx *ScenarioContext) *ScenarioContext {
+		// TODO
+		return ctx
+	}
+}
+
+func (s Scenario) Run(t *testing.T, opts ...RunOpts) bool {
+	ctx := &ScenarioContext{
+		Namespace: "default",
+	}
+
+	for _, o := range opts {
+		o(ctx)
+	}
+
+	defer func(ctx *ScenarioContext) {
+		for _, f := range ctx.Finalizer {
+			if err := f(); err != nil {
+				panic(err)
+			}
+		}
+	}(ctx)
+
+	return t.Run(s.Name, func(t *testing.T) {
+		if s.Given != nil {
+			if err := s.Given(ctx); err != nil {
+				t.Fatalf("failed to create given setup: %v", err)
+			}
+		}
+
+		if s.When != nil {
+			if err := s.When(ctx); err != nil {
+				t.Errorf("failed to evaluate state: %v", err)
+			}
+		}
+
+		if s.Given != nil {
+			if err := s.Then(ctx); err != nil {
+				t.Errorf("checks failed: %v", err)
+			}
+		}
+	})
+}
+
+type Setup func(ctx *ScenarioContext) error
+
+func Setups(ss ...Setup) Setup {
+	return func(ctx *ScenarioContext) error {
+		for _, s := range ss {
+			if err := s(ctx); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+type Condition func(ctx *ScenarioContext) error
+
+func Conditions(cs ...Condition) Condition {
+	return func(ctx *ScenarioContext) error {
+		for _, c := range cs {
+			if err := c(ctx); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+type Check func(ctx *ScenarioContext) error
+
+func Checks(cs ...Check) Check {
+	return func(ctx *ScenarioContext) error {
+		for _, c := range cs {
+			if err := c(ctx); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+type Finalizer func() error


### PR DESCRIPTION
This PR adds a basic end to end test for kube-rbac-proxy.
The most basic test simply `curl`s a deployment that is guarded by the kube-rbac-proxy. The first one tests if the client fails, if not sufficient rights and the second tests checks if the clients succeeds with the correct rbac rules added.

TODO:
* [x] Integrate with Travis and start a [kind](https://github.com/kubernetes-sigs/kind) cluster there. See https://github.com/xmudrii/travis-kind