### PR TITLE
main.go: Allow setting min TLS to 1.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11-alpine AS build
+FROM golang:1.12-alpine AS build
 RUN apk add --update make
 WORKDIR /go/src/github.com/brancz/kube-rbac-proxy
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,6 @@ generate: embedmd
 	@$(GOPATH)/bin/embedmd -w `find ./ -path ./vendor -prune -o -name "*.md" -print`
 
 embedmd:
-	@go get github.com/campoy/embedmd
+	@GO111MODULE=off go get github.com/campoy/embedmd
 
 .PHONY: all check-license crossbuild build container curl-container test generate embedmd

--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ var versions = map[string]uint16{
 	"VersionTLS10": tls.VersionTLS10,
 	"VersionTLS11": tls.VersionTLS11,
 	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
 }
 
 func tlsVersion(versionName string) (uint16, error) {
@@ -81,6 +82,10 @@ func tlsVersion(versionName string) (uint16, error) {
 		return version, nil
 	}
 	return 0, fmt.Errorf("unknown tls version %q", versionName)
+}
+
+func init() {
+	os.Setenv("GODEBUG", os.Getenv("GODEBUG")+",tls13=1")
 }
 
 func main() {

--- a/test/e2e/basics.go
+++ b/test/e2e/basics.go
@@ -25,7 +25,7 @@ import (
 
 func testBasics(s *kubetest.Suite) kubetest.TestSuite {
 	return func(t *testing.T) {
-		command := `curl -v -s -k --fail -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" https://kube-rbac-proxy.default.svc.cluster.local:8443/metrics`
+		command := `curl --tlsv1.3 -v -s -k --fail -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" https://kube-rbac-proxy.default.svc.cluster.local:8443/metrics`
 
 		kubetest.Scenario{
 			Name: "NoRBAC",


### PR DESCRIPTION
Fixes parts of https://github.com/brancz/kube-rbac-proxy/issues/40

@s-urbaniak @metalmatze @paulfantom @squat