### PR TITLE
Use go env GOARCH in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: check-license build generate test
 
 GITHUB_URL=github.com/brancz/kube-rbac-proxy
 GOOS?=$(shell uname -s | tr A-Z a-z)
-GOARCH?=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m)))
+GOARCH?=$(shell go env GOARCH)
 OUT_DIR=_output
 BIN?=kube-rbac-proxy
 VERSION?=$(shell cat VERSION)


### PR DESCRIPTION
On aarch64, GOARCH is 'arm64'.  Instead of making this even longer, just get GOARCH from go itself.