### PR TITLE
Add stale cache option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Usage of _output/kube-rbac-proxy:
       --ignore-paths strings                        Comma-separated list of paths against which kube-rbac-proxy will proxy without performing an authentication or authorization check. Cannot be used with --allow-paths.
       --insecure-listen-address string              The address the kube-rbac-proxy HTTP server should listen on.
       --kubeconfig string                           Path to a kubeconfig file, specifying how to connect to the API server. If unset, in-cluster configuration will be used
+      --stale-cache-interval string	                The interval to keep auth request review result for in case of unconsciousness of apiserver (default 0)
       --log_backtrace_at traceLocation              when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                              If non-empty, write log files in this directory
       --log_file string                             If non-empty, use this log file

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Usage of _output/kube-rbac-proxy:
       --ignore-paths strings                        Comma-separated list of paths against which kube-rbac-proxy will proxy without performing an authentication or authorization check. Cannot be used with --allow-paths.
       --insecure-listen-address string              The address the kube-rbac-proxy HTTP server should listen on.
       --kubeconfig string                           Path to a kubeconfig file, specifying how to connect to the API server. If unset, in-cluster configuration will be used
-      --stale-cache-interval string                 The interval to keep auth request review results for in case of unavailability of kube-apiserver (default 0)
       --log_backtrace_at traceLocation              when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                              If non-empty, write log files in this directory
       --log_file string                             If non-empty, use this log file
@@ -57,6 +56,7 @@ Usage of _output/kube-rbac-proxy:
       --secure-listen-address string                The address the kube-rbac-proxy HTTPs server should listen on.
       --skip_headers                                If true, avoid header prefixes in the log messages
       --skip_log_headers                            If true, avoid headers when opening log files
+      --stale-cache-interval duration               The interval to keep auth request review results for in case of unavailability of kube-apiserver.
       --stderrthreshold severity                    logs at or above this threshold go to stderr (default 2)
       --tls-cert-file string                        File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert)
       --tls-cipher-suites strings                   Comma-separated list of cipher suites for the server. Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants). If omitted, the default Go cipher suites will be used

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Usage of _output/kube-rbac-proxy:
       --ignore-paths strings                        Comma-separated list of paths against which kube-rbac-proxy will proxy without performing an authentication or authorization check. Cannot be used with --allow-paths.
       --insecure-listen-address string              The address the kube-rbac-proxy HTTP server should listen on.
       --kubeconfig string                           Path to a kubeconfig file, specifying how to connect to the API server. If unset, in-cluster configuration will be used
-      --stale-cache-interval string	                The interval to keep auth request review result for in case of unconsciousness of apiserver (default 0)
+      --stale-cache-interval string                 The interval to keep auth request review results for in case of unavailability of kube-apiserver (default 0)
       --log_backtrace_at traceLocation              when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                              If non-empty, write log files in this directory
       --log_file string                             If non-empty, use this log file

--- a/main.go
+++ b/main.go
@@ -106,6 +106,9 @@ func main() {
 	flagset.BoolVar(&cfg.upstreamForceH2C, "upstream-force-h2c", false, "Force h2c to communiate with the upstream. This is required when the upstream speaks h2c(http/2 cleartext - insecure variant of http/2) only. For example, go-grpc server in the insecure mode, such as helm's tiller w/o TLS, speaks h2c only")
 	flagset.StringVar(&cfg.upstreamCAFile, "upstream-ca-file", "", "The CA the upstream uses for TLS connection. This is required when the upstream uses TLS and its own CA certificate")
 	flagset.StringVar(&configFileName, "config-file", "", "Configuration file to configure kube-rbac-proxy.")
+	flagset.StringSliceVar(&cfg.allowPaths, "allow-paths", nil, "Comma-separated list of paths against which kube-rbac-proxy matches the incoming request. If the request doesn't match, kube-rbac-proxy responds with a 404 status code. If omitted, the incoming request path isn't checked. Cannot be used with --ignore-paths.")
+	flagset.StringSliceVar(&cfg.ignorePaths, "ignore-paths", nil, "Comma-separated list of paths against which kube-rbac-proxy will proxy without performing an authentication or authorization check. Cannot be used with --allow-paths.")
+	flagset.DurationVar(&cfg.staleCacheTTL, "stale-cache-interval", 0*time.Minute, "The interval to keep auth request review results for in case of unavailability of kube-apiserver.")
 
 	// TLS flags
 	flagset.StringVar(&cfg.tls.certFile, "tls-cert-file", "", "File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert)")

--- a/pkg/proxy/cache.go
+++ b/pkg/proxy/cache.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 Frederic Branczyk All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package proxy
 
 import (

--- a/pkg/proxy/cache.go
+++ b/pkg/proxy/cache.go
@@ -1,0 +1,49 @@
+package proxy
+
+import (
+	"time"
+
+	utilcache "k8s.io/apimachinery/pkg/util/cache"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+)
+
+type authResponseCache interface {
+	Add(key string, value *authenticator.Response)
+	Get(key string) (*authenticator.Response, bool)
+	Remove(key string)
+}
+
+var (
+	_ authResponseCache = &lruCache{}
+	_ authResponseCache = &fakeCache{}
+)
+
+// lruCache is wrapper around kubernetes lru cache to make the ttl setting a property of the cache.
+type lruCache struct {
+	wrap *utilcache.LRUExpireCache
+	ttl  time.Duration
+}
+
+func newLRUTokenCache(ttl time.Duration) *lruCache {
+	return &lruCache{
+		wrap: utilcache.NewLRUExpireCache(4096),
+		ttl:  ttl,
+	}
+}
+
+func (c *lruCache) Add(key string, value *authenticator.Response) { c.wrap.Add(key, value, c.ttl) }
+func (c *lruCache) Remove(key string)                             { c.wrap.Remove(key) }
+func (c *lruCache) Get(key string) (*authenticator.Response, bool) {
+	obj, ok := c.wrap.Get(key)
+	if obj == nil {
+		return nil, ok
+	}
+	return obj.(*authenticator.Response), ok
+}
+
+// fakeCache is a dummy substitute to keep working with cache simple.
+type fakeCache struct{}
+
+func (*fakeCache) Add(_ string, _ *authenticator.Response)      {}
+func (*fakeCache) Remove(_ string)                              {}
+func (*fakeCache) Get(_ string) (*authenticator.Response, bool) { return nil, false }


### PR DESCRIPTION
### Description
This PR adds the new command-line option - `--stale-cache-interval`. 
When option set, it's enabled additional lru cache to store token review results.

### Motivation
kube-rbac-proxy is a handy tool to protect your metrics. But when apiserver not responding, you are completely lost the possibility to access any metrics. The stale cache makes kube-rbac-proxy works without apiserver for some time.