### PR TITLE
Build process refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _output/
+manifest-tool

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 language: go
 
 go:
@@ -18,7 +19,8 @@ services:
 
 jobs:
   include:
-    - stage: Integration Tests
+    - name: Integration Tests
+      stage: test
       before_script:
         - curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-amd64 && chmod +x kind && sudo mv kind /usr/local/bin/
         - kind create cluster --config test/e2e/kind-config/kind-config.yaml
@@ -26,3 +28,13 @@ jobs:
         - VERSION=local make container
         - kind load docker-image quay.io/brancz/kube-rbac-proxy:local
         - make test-e2e
+    - name: Push container images
+      stage: push-docker-image
+      script:
+        - "echo ${QUAY_PASSWORD} | docker login -u ${QUAY_USERNAME} --password-stdin quay.io"
+        - VERSION=$TRAVIS_TAG make push
+
+stages:
+  - name: test
+  - name: push-docker-image
+    if: (type != pull_request) AND (tag =~ ^v)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,6 @@
-FROM golang:1.13-alpine AS build
-ENV GOFLAGS="-mod=vendor"
-RUN apk add --update make && apk add --no-cache git
-WORKDIR /go/src/github.com/brancz/kube-rbac-proxy
-COPY . .
-RUN make build && cp /go/src/github.com/brancz/kube-rbac-proxy/_output/linux/$(go env GOARCH)/kube-rbac-proxy /usr/local/bin
+FROM gcr.io/distroless/static
 
-FROM alpine:3.11
-RUN apk add -U --no-cache ca-certificates && rm -rf /var/cache/apk/*
-COPY --from=build /usr/local/bin/kube-rbac-proxy .
-ENTRYPOINT ["./kube-rbac-proxy"]
+COPY _output/linux/$(go env GOARCH)/kube-rbac-proxy /usr/local/bin/kube-rbac-proxy
+
 EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/kube-rbac-proxy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM gcr.io/distroless/static
 
-COPY _output/linux/$(go env GOARCH)/kube-rbac-proxy /usr/local/bin/kube-rbac-proxy
+ARG BINARY=kube-rbac-proxy-linux-amd64
+COPY _output/$BINARY /usr/local/bin/kube-rbac-proxy
 
 EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/kube-rbac-proxy"]

--- a/Makefile
+++ b/Makefile
@@ -13,23 +13,54 @@ PKGS=$(shell go list ./... | grep -v /vendor/)
 DOCKER_REPO?=quay.io/brancz/kube-rbac-proxy
 KUBECONFIG?=$(HOME)/.kube/config
 
+ALL_ARCH=amd64 arm arm64 ppc64le s390x
+ALL_PLATFORMS=$(addprefix linux/,$(ALL_ARCH))
+ALL_BINARIES ?= $(addprefix $(OUT_DIR)/$(BIN)-, \
+				$(addprefix linux-,$(ALL_ARCH)) \
+				darwin-amd64 \
+				windows-amd64.exe)
+
+
 check-license:
 	@echo ">> checking license headers"
 	@./scripts/check_license.sh
 
-crossbuild:
-	@GOOS=darwin ARCH=amd64 $(MAKE) -s build
-	@GOOS=linux ARCH=amd64 $(MAKE) -s build
-	@GOOS=windows ARCH=amd64 $(MAKE) -s build
+crossbuild: $(ALL_BINARIES)
 
-build:
-	@$(eval OUTPUT=$(OUT_DIR)/$(GOOS)/$(GOARCH)/$(BIN))
-	@echo ">> building for $(GOOS)/$(GOARCH) to $(OUTPUT)"
-	@mkdir -p $(OUT_DIR)/$(GOOS)/$(GOARCH)
-	@CGO_ENABLED=0 go build --installsuffix cgo -o $(OUTPUT) $(GITHUB_URL)
+$(OUT_DIR)/$(BIN): $(OUT_DIR)/$(BIN)-$(GOOS)-$(GOARCH)
+	cp $(OUT_DIR)/$(BIN)-$(GOOS)-$(GOARCH) $(OUT_DIR)/$(BIN)
 
-container:
-	docker build -t $(DOCKER_REPO):$(VERSION) .
+$(OUT_DIR)/$(BIN)-%:
+	@echo ">> building for $(GOOS)/$(GOARCH) to $(OUT_DIR)/$(BIN)-$*"
+	GOARCH=$(word 2,$(subst -, ,$(*:.exe=))) \
+	GOOS=$(word 1,$(subst -, ,$(*:.exe=))) \
+	CGO_ENABLED=0 \
+	go build --installsuffix cgo -o $(OUT_DIR)/$(BIN)-$* $(GITHUB_URL)
+
+build: $(OUT_DIR)/$(BIN)
+
+container: $(OUT_DIR)/$(BIN)-$(GOOS)-$(GOARCH) Dockerfile
+	docker build --build-arg BINARY=$(BIN)-$(GOOS)-$(GOARCH) -t $(DOCKER_REPO):$(VERSION)-$(GOARCH) .
+ifeq ($(GOARCH), amd64)
+	docker tag $(DOCKER_REPO):$(VERSION)-$(GOARCH) $(DOCKER_REPO):$(VERSION)
+endif
+
+
+manifest-tool:
+	curl -fsSL https://github.com/estesp/manifest-tool/releases/download/v1.0.2/manifest-tool-linux-amd64 > ./manifest-tool
+	chmod +x ./manifest-tool
+
+push-%:
+	$(MAKE) GOARCH=$* container
+	docker push $(DOCKER_REPO):$(VERSION)-$*
+
+comma:= ,
+empty:=
+space:= $(empty) $(empty)
+manifest-push: manifest-tool
+	./manifest-tool push from-args --platforms $(subst $(space),$(comma),$(ALL_PLATFORMS)) --template $(DOCKER_REPO):$(VERSION)-ARCH --target $(DOCKER_REPO):$(VERSION)
+
+push: crossbuild manifest-tool $(addprefix push-,$(ALL_ARCH)) manifest-push
 
 curl-container:
 	docker build -f ./examples/example-client/Dockerfile -t quay.io/brancz/krp-curl:v0.0.1 .
@@ -61,4 +92,4 @@ generate: build embedmd
 embedmd:
 	@go get github.com/campoy/embedmd
 
-.PHONY: all check-license crossbuild build container curl-container test generate embedmd
+.PHONY: all check-license crossbuild build container push push-% manifest-push curl-container test generate embedmd


### PR DESCRIPTION
- use gcr.io/distroless/static as it already has ca-certificates built-in and is cross-platform
- allow building multi-arch images (modeled after https://github.com/jimmidyson/configmap-reload/blob/master/Makefile)
- automate building images when new tag is pushed

Last feature needs adding quay credentials to travis CI. Following vairables need to be added:
- `QUAY_USERNAME`
- `QUAY_PASSWORD`