### PR TITLE
.travis.yaml: push images tagged with hash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,10 @@ jobs:
       stage: push-docker-image
       script:
         - "echo ${QUAY_PASSWORD} | docker login -u ${QUAY_USERNAME} --password-stdin quay.io"
-        - VERSION=$TRAVIS_TAG make push
+        - [ "$TRAVIS_BRANCH" = "master" ] && VERSION="$(git rev-parse --abbrev-ref HEAD | tr / -)-$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)" make push
+        - [ -n "$TRAVIS_TAG" ] && VERSION=$TRAVIS_TAG make push
 
 stages:
   - name: test
   - name: push-docker-image
-    if: (type != pull_request) AND (tag =~ ^v)
+    if: (type != pull_request)


### PR DESCRIPTION
I think it would be nice to have images pushed to quay for every hash,
that would enable better testing. This commit makes it so that every
commit merged to master results in an image pushed to quay tagged like:
master-2020-05-06-37157950.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @paulfantom 