### PR TITLE
.travis: quote ampersands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ jobs:
       stage: push-docker-image
       script:
         - "echo ${QUAY_PASSWORD} | docker login -u ${QUAY_USERNAME} --password-stdin quay.io"
-        - [ "$TRAVIS_BRANCH" = "master" ] && VERSION="$(git rev-parse --abbrev-ref HEAD | tr / -)-$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)" make push
-        - [ -n "$TRAVIS_TAG" ] && VERSION=$TRAVIS_TAG make push
+        - '[ "$TRAVIS_BRANCH" = "master" ] && VERSION="$(git rev-parse --abbrev-ref HEAD | tr / -)-$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)" make push'
+        - '[ -n "$TRAVIS_TAG" ] && VERSION=$TRAVIS_TAG make push'
 
 stages:
   - name: test


### PR DESCRIPTION
PR #70 introduced new scripts into the .travis.yml file, which did not
correctly escape `&` characters, which are anchors in YAML.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>