### PR TITLE
Fix pushing images to quay.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Push container images
       stage: push-docker-image
       script:
+        - "sudo chmod o+x /etc/docker"
         - "echo ${QUAY_PASSWORD} | docker login -u ${QUAY_USERNAME} --password-stdin quay.io"
         - '[ "$TRAVIS_BRANCH" = "master" ] && VERSION="$(git rev-parse --abbrev-ref HEAD | tr / -)-$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)" make push'
         - '[ -n "$TRAVIS_TAG" ] && VERSION=$TRAVIS_TAG make push'


### PR DESCRIPTION
Currently CI cannot push images due to https://github.com/docker/for-linux/issues/396. This is a workaround which is confirmed to work and was already applied in [coreos/prometheus-operator](https://github.com/coreos/prometheus-operator/pull/3184)

cc @squat 