### PR TITLE
.travis: do not fail when variables are not defined

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ jobs:
       script:
         - "sudo chmod o+x /etc/docker"
         - "echo ${QUAY_PASSWORD} | docker login -u ${QUAY_USERNAME} --password-stdin quay.io"
-        - '[ "$TRAVIS_BRANCH" = "master" ] && VERSION="$(git rev-parse --abbrev-ref HEAD | tr / -)-$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)" make push'
-        - '[ -n "$TRAVIS_TAG" ] && VERSION=$TRAVIS_TAG make push'
+        - '[ "$TRAVIS_BRANCH" = "master" ] && VERSION="$(git rev-parse --abbrev-ref HEAD | tr / -)-$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)" make push || :'
+        - '[ -n "$TRAVIS_TAG" ] && VERSION=$TRAVIS_TAG make push || :'
 
 stages:
   - name: test


### PR DESCRIPTION
Shell test result is passed as the exit code:
```
sh-5.0$ [ -n "$TRAVIS_TAG" ] && echo "OK"
sh-5.0$ echo $?
1
```
This causes incorrect test results.

/cc @brancz 