### PR TITLE
switch to nonroot user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM gcr.io/distroless/static
+FROM gcr.io/distroless/static:nonroot
+
+USER 65532:65532
 
 ARG BINARY=kube-rbac-proxy-linux-amd64
 COPY _output/$BINARY /usr/local/bin/kube-rbac-proxy


### PR DESCRIPTION
Some background here - https://github.com/kubernetes-sigs/kubebuilder/issues/1637 

This change makes the kube-rbac-proxy run as nonroot by default following principle of least privilege since there is really no need for this to run as root as far as I can see. 

The UID:GID comes from - https://github.com/GoogleContainerTools/distroless/blob/master/base/base.bzl#L7 