### PR TITLE
Add support for ignore-paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ All command line flags:
 $ kube-rbac-proxy -h
 Usage of _output/linux/amd64/kube-rbac-proxy:
       --add_dir_header                              If true, adds the file directory to the header
-      --allow-paths strings                         Comma-separated list of paths against which kube-rbac-proxy matches the incoming request. If the request doesn't match, kube-rbac-proxy responds with a 404 status code. If omitted, the incoming request path isn't checked.
+      --allow-paths strings                         Comma-separated list of paths against which kube-rbac-proxy matches the incoming request. If the request doesn't match, kube-rbac-proxy responds with a 404 status code. If omitted, the incoming request path isn't checked. Cannot be used with --ignore-paths.
       --alsologtostderr                             log to standard error as well as files
       --auth-header-fields-enabled                  When set to true, kube-rbac-proxy adds auth-related fields to the headers of http requests sent to the upstream
       --auth-header-groups-field-name string        The name of the field inside a http(2) request header to tell the upstream server about the user's groups (default "x-remote-groups")
@@ -38,6 +38,7 @@ Usage of _output/linux/amd64/kube-rbac-proxy:
       --auth-token-audiences strings                Comma-separated list of token audiences to accept. By default a token does not have to have any specific audience. It is recommended to set a specific audience.
       --client-ca-file string                       If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.
       --config-file string                          Configuration file to configure kube-rbac-proxy.
+      --ignore-paths strings                        Comma-separated list of paths against which kube-rbac-proxy will proxy without performing an authentication or authorization check. Cannot be used with --allow-paths.
       --insecure-listen-address string              The address the kube-rbac-proxy HTTP server should listen on.
       --kubeconfig string                           Path to a kubeconfig file, specifying how to connect to the API server. If unset, in-cluster configuration will be used
       --log_backtrace_at traceLocation              when logging hits line file:N, emit a stack trace (default :0)

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ type config struct {
 	tls                   tlsConfig
 	kubeconfigLocation    string
 	allowPaths            []string
+	ignorePaths           []string
 }
 
 type tlsConfig struct {
@@ -116,7 +117,8 @@ func main() {
 	flagset.BoolVar(&cfg.upstreamForceH2C, "upstream-force-h2c", false, "Force h2c to communiate with the upstream. This is required when the upstream speaks h2c(http/2 cleartext - insecure variant of http/2) only. For example, go-grpc server in the insecure mode, such as helm's tiller w/o TLS, speaks h2c only")
 	flagset.StringVar(&cfg.upstreamCAFile, "upstream-ca-file", "", "The CA the upstream uses for TLS connection. This is required when the upstream uses TLS and its own CA certificate")
 	flagset.StringVar(&configFileName, "config-file", "", "Configuration file to configure kube-rbac-proxy.")
-	flagset.StringSliceVar(&cfg.allowPaths, "allow-paths", nil, "Comma-separated list of paths against which kube-rbac-proxy matches the incoming request. If the request doesn't match, kube-rbac-proxy responds with a 404 status code. If omitted, the incoming request path isn't checked.")
+	flagset.StringSliceVar(&cfg.allowPaths, "allow-paths", nil, "Comma-separated list of paths against which kube-rbac-proxy matches the incoming request. If the request doesn't match, kube-rbac-proxy responds with a 404 status code. If omitted, the incoming request path isn't checked. Cannot be used with --ignore-paths.")
+	flagset.StringSliceVar(&cfg.ignorePaths, "ignore-paths", nil, "Comma-separated list of paths against which kube-rbac-proxy will proxy without performing an authentication or authorization check. Cannot be used with --allow-paths.")
 
 	// TLS flags
 	flagset.StringVar(&cfg.tls.certFile, "tls-cert-file", "", "File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert)")
@@ -213,6 +215,10 @@ func main() {
 		klog.Fatalf("Failed to set up upstream TLS connection: %v", err)
 	}
 
+	if len(cfg.allowPaths) > 0 && len(cfg.ignorePaths) > 0 {
+		klog.Fatal("Cannot use --allow-paths and --ignore-paths together.")
+	}
+
 	proxy := httputil.NewSingleHostReverseProxy(upstreamURL)
 	proxy.Transport = upstreamTransport
 	mux := http.NewServeMux()
@@ -228,9 +234,20 @@ func main() {
 			http.NotFound(w, req)
 			return
 		}
-		ok := auth.Handle(w, req)
-		if !ok {
-			return
+
+		ignorePathFound := false
+		for _, path := range cfg.ignorePaths {
+			if req.URL.Path == path {
+				ignorePathFound = true
+				break
+			}
+		}
+
+		if !ignorePathFound {
+			ok := auth.Handle(w, req)
+			if !ok {
+				return
+			}
 		}
 
 		proxy.ServeHTTP(w, req)

--- a/test/e2e/ignorepaths/clusterRole-client.yaml
+++ b/test/e2e/ignorepaths/clusterRole-client.yaml
@@ -1,0 +1,7 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: metrics
+rules:
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]

--- a/test/e2e/ignorepaths/clusterRole.yaml
+++ b/test/e2e/ignorepaths/clusterRole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-rbac-proxy
+  namespace: default
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources:
+      - tokenreviews
+    verbs: ["create"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources:
+      - subjectaccessreviews
+    verbs: ["create"]

--- a/test/e2e/ignorepaths/clusterRoleBinding-client.yaml
+++ b/test/e2e/ignorepaths/clusterRoleBinding-client.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metrics
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: default

--- a/test/e2e/ignorepaths/clusterRoleBinding.yaml
+++ b/test/e2e/ignorepaths/clusterRoleBinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-rbac-proxy
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-rbac-proxy
+subjects:
+  - kind: ServiceAccount
+    name: kube-rbac-proxy
+    namespace: default

--- a/test/e2e/ignorepaths/deployment.yaml
+++ b/test/e2e/ignorepaths/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-rbac-proxy
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-rbac-proxy
+  template:
+    metadata:
+      labels:
+        app: kube-rbac-proxy
+    spec:
+      serviceAccountName: kube-rbac-proxy
+      containers:
+        - name: kube-rbac-proxy
+          image: quay.io/brancz/kube-rbac-proxy:local
+          args:
+            - "--secure-listen-address=0.0.0.0:8443"
+            - "--upstream=http://127.0.0.1:8081/"
+            - "--ignore-paths=/metrics"
+            - "--logtostderr=true"
+            - "--v=10"
+          ports:
+            - containerPort: 8443
+              name: https
+        - name: prometheus-example-app
+          image: quay.io/brancz/prometheus-example-app:v0.1.0
+          args:
+            - "--bind=127.0.0.1:8081"

--- a/test/e2e/ignorepaths/service.yaml
+++ b/test/e2e/ignorepaths/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-rbac-proxy
+  name: kube-rbac-proxy
+  namespace: default
+spec:
+  ports:
+    - name: https
+      port: 8443
+      targetPort: https
+  selector:
+    app: kube-rbac-proxy

--- a/test/e2e/ignorepaths/serviceAccount.yaml
+++ b/test/e2e/ignorepaths/serviceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-rbac-proxy
+  namespace: default

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -52,6 +52,7 @@ func Test(t *testing.T) {
 		"Basics":        testBasics(suite),
 		"TokenAudience": testTokenAudience(suite),
 		"AllowPath":     testAllowPathsRegexp(suite),
+		"IgnorePath":    testIgnorePaths(suite),
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
Do not perform any auth check if the request path matches any specified by the new ignore-paths flag, just proxy. Closes #25 

I *think* this can live alongside `--allow-paths` but interested to hear your thoughts.