### PR TITLE
Rewrite from header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ OUT_DIR=_output
 BIN?=kube-rbac-proxy
 VERSION?=$(shell cat VERSION)-$(shell git rev-parse --short HEAD)
 PKGS=$(shell go list ./... )
-DOCKER_REPO?=registry.hub.docker.com/marpiot/kube-rbac-proxy
+DOCKER_REPO?=quay.io/brancz/kube-rbac-proxy
 KUBECONFIG?=$(HOME)/.kube/config
 
 ALL_ARCH=amd64 arm arm64 ppc64le s390x
@@ -40,9 +40,9 @@ $(OUT_DIR)/$(BIN)-%:
 build: $(OUT_DIR)/$(BIN)
 
 container: $(OUT_DIR)/$(BIN)-$(GOOS)-$(GOARCH) Dockerfile
-	podman build --build-arg BINARY=$(BIN)-$(GOOS)-$(GOARCH) -t $(DOCKER_REPO):$(VERSION)-$(GOARCH) .
+	docker build --build-arg BINARY=$(BIN)-$(GOOS)-$(GOARCH) -t $(DOCKER_REPO):$(VERSION)-$(GOARCH) .
 ifeq ($(GOARCH), amd64)
-	podman tag $(DOCKER_REPO):$(VERSION)-$(GOARCH) $(DOCKER_REPO):$(VERSION)
+	docker tag $(DOCKER_REPO):$(VERSION)-$(GOARCH) $(DOCKER_REPO):$(VERSION)
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ OUT_DIR=_output
 BIN?=kube-rbac-proxy
 VERSION?=$(shell cat VERSION)-$(shell git rev-parse --short HEAD)
 PKGS=$(shell go list ./... )
-DOCKER_REPO?=quay.io/brancz/kube-rbac-proxy
+DOCKER_REPO?=registry.hub.docker.com/marpiot/kube-rbac-proxy
 KUBECONFIG?=$(HOME)/.kube/config
 
 ALL_ARCH=amd64 arm arm64 ppc64le s390x
@@ -40,9 +40,9 @@ $(OUT_DIR)/$(BIN)-%:
 build: $(OUT_DIR)/$(BIN)
 
 container: $(OUT_DIR)/$(BIN)-$(GOOS)-$(GOARCH) Dockerfile
-	docker build --build-arg BINARY=$(BIN)-$(GOOS)-$(GOARCH) -t $(DOCKER_REPO):$(VERSION)-$(GOARCH) .
+	podman build --build-arg BINARY=$(BIN)-$(GOOS)-$(GOARCH) -t $(DOCKER_REPO):$(VERSION)-$(GOARCH) .
 ifeq ($(GOARCH), amd64)
-	docker tag $(DOCKER_REPO):$(VERSION)-$(GOARCH) $(DOCKER_REPO):$(VERSION)
+	podman tag $(DOCKER_REPO):$(VERSION)-$(GOARCH) $(DOCKER_REPO):$(VERSION)
 endif
 
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/ghodss/yaml v1.0.0
+	github.com/google/go-cmp v0.5.4
 	github.com/oklog/run v1.0.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=

--- a/pkg/authz/auth.go
+++ b/pkg/authz/auth.go
@@ -36,11 +36,18 @@ type Config struct {
 // rewritten on a given request.
 type SubjectAccessReviewRewrites struct {
 	ByQueryParameter *QueryParameterRewriteConfig `json:"byQueryParameter,omitempty"`
+	ByHTTPHeader     *HTTPHeaderRewriteConfig     `json:"byHttpHeader,omitempty"`
 }
 
 // QueryParameterRewriteConfig describes which HTTP URL query parameter is to
 // be used to rewrite a SubjectAccessReview on a given request.
 type QueryParameterRewriteConfig struct {
+	Name string `json:"name,omitempty"`
+}
+
+// HTTPHeaderRewriteConfig describes which HTTP header is to
+// be used to rewrite a SubjectAccessReview on a given request.
+type HTTPHeaderRewriteConfig struct {
 	Name string `json:"name,omitempty"`
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -125,7 +125,7 @@ type krpAuthorizerAttributesGetter struct {
 }
 
 // GetRequestAttributes populates authorizer attributes for the requests to kube-rbac-proxy.
-func (n krpAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *http.Request) (allAttrs []authorizer.Attributes) {
+func (n krpAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *http.Request) []authorizer.Attributes {
 	apiVerb := ""
 	switch r.Method {
 	case "POST":
@@ -140,15 +140,58 @@ func (n krpAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *http
 		apiVerb = "delete"
 	}
 
-	defer func() {
-		for attrs := range allAttrs {
-			klog.V(5).Infof("kube-rbac-proxy request attributes: attrs=%#v", attrs)
-		}
-	}()
+	allAttrs := []authorizer.Attributes{}
 
-	if n.authzConfig.ResourceAttributes == nil {
+	if n.authzConfig.ResourceAttributes != nil {
+		if n.authzConfig.Rewrites != nil {
+			params := []string{}
+			if n.authzConfig.Rewrites.ByQueryParameter != nil && n.authzConfig.Rewrites.ByQueryParameter.Name != "" {
+				if ps, ok := r.URL.Query()[n.authzConfig.Rewrites.ByQueryParameter.Name]; ok {
+					params = append(params, ps...)
+				}
+			}
+			if n.authzConfig.Rewrites.ByHTTPHeader != nil && n.authzConfig.Rewrites.ByHTTPHeader.Name != "" {
+				if p := r.Header.Get(n.authzConfig.Rewrites.ByHTTPHeader.Name); p != "" {
+					params = append(params, p)
+				}
+			}
+
+			if len(params) == 0 {
+				return nil
+			}
+
+			for _, param := range params {
+				attrs := authorizer.AttributesRecord{
+					User:            u,
+					Verb:            apiVerb,
+					Namespace:       templateWithValue(n.authzConfig.ResourceAttributes.Namespace, param),
+					APIGroup:        templateWithValue(n.authzConfig.ResourceAttributes.APIGroup, param),
+					APIVersion:      templateWithValue(n.authzConfig.ResourceAttributes.APIVersion, param),
+					Resource:        templateWithValue(n.authzConfig.ResourceAttributes.Resource, param),
+					Subresource:     templateWithValue(n.authzConfig.ResourceAttributes.Subresource, param),
+					Name:            templateWithValue(n.authzConfig.ResourceAttributes.Name, param),
+					ResourceRequest: true,
+				}
+				allAttrs = append(allAttrs, attrs)
+			}
+		} else {
+			attrs := authorizer.AttributesRecord{
+				User:            u,
+				Verb:            apiVerb,
+				Namespace:       n.authzConfig.ResourceAttributes.Namespace,
+				APIGroup:        n.authzConfig.ResourceAttributes.APIGroup,
+				APIVersion:      n.authzConfig.ResourceAttributes.APIVersion,
+				Resource:        n.authzConfig.ResourceAttributes.Resource,
+				Subresource:     n.authzConfig.ResourceAttributes.Subresource,
+				Name:            n.authzConfig.ResourceAttributes.Name,
+				ResourceRequest: true,
+			}
+			allAttrs = append(allAttrs, attrs)
+		}
+	} else {
+		requestPath := r.URL.Path
 		// Default attributes mirror the API attributes that would allow this access to kube-rbac-proxy
-		allAttrs = append(allAttrs, authorizer.AttributesRecord{
+		attrs := authorizer.AttributesRecord{
 			User:            u,
 			Verb:            apiVerb,
 			Namespace:       "",
@@ -158,60 +201,16 @@ func (n krpAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *http
 			Subresource:     "",
 			Name:            "",
 			ResourceRequest: false,
-			Path:            r.URL.Path,
-		})
-		return
-	}
-
-	if n.authzConfig.Rewrites == nil {
-		allAttrs = append(allAttrs, authorizer.AttributesRecord{
-			User:            u,
-			Verb:            apiVerb,
-			Namespace:       n.authzConfig.ResourceAttributes.Namespace,
-			APIGroup:        n.authzConfig.ResourceAttributes.APIGroup,
-			APIVersion:      n.authzConfig.ResourceAttributes.APIVersion,
-			Resource:        n.authzConfig.ResourceAttributes.Resource,
-			Subresource:     n.authzConfig.ResourceAttributes.Subresource,
-			Name:            n.authzConfig.ResourceAttributes.Name,
-			ResourceRequest: true,
-		})
-
-		return
-	}
-
-	params := []string{}
-
-	if n.authzConfig.Rewrites.ByQueryParameter != nil && n.authzConfig.Rewrites.ByQueryParameter.Name != "" {
-		if ps, ok := r.URL.Query()[n.authzConfig.Rewrites.ByQueryParameter.Name]; ok {
-			params = append(params, ps...)
+			Path:            requestPath,
 		}
+		allAttrs = append(allAttrs, attrs)
 	}
 
-	if n.authzConfig.Rewrites.ByHTTPHeader != nil && n.authzConfig.Rewrites.ByHTTPHeader.Name != "" {
-		if p := r.Header.Get(n.authzConfig.Rewrites.ByHTTPHeader.Name); p != "" {
-			params = append(params, p)
-		}
+	for attrs := range allAttrs {
+		klog.V(5).Infof("kube-rbac-proxy request attributes: attrs=%#+v", attrs)
 	}
 
-	if len(params) == 0 {
-		return
-	}
-
-	for _, param := range params {
-		allAttrs = append(allAttrs, authorizer.AttributesRecord{
-			User:            u,
-			Verb:            apiVerb,
-			Namespace:       templateWithValue(n.authzConfig.ResourceAttributes.Namespace, param),
-			APIGroup:        templateWithValue(n.authzConfig.ResourceAttributes.APIGroup, param),
-			APIVersion:      templateWithValue(n.authzConfig.ResourceAttributes.APIVersion, param),
-			Resource:        templateWithValue(n.authzConfig.ResourceAttributes.Resource, param),
-			Subresource:     templateWithValue(n.authzConfig.ResourceAttributes.Subresource, param),
-			Name:            templateWithValue(n.authzConfig.ResourceAttributes.Name, param),
-			ResourceRequest: true,
-		})
-	}
-
-	return
+	return allAttrs
 }
 
 // DeepCopy of Proxy Configuration

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -193,7 +193,7 @@ func (n krpAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *http
 	}
 
 	if len(params) == 0 {
-		return allAttrs
+		return nil
 	}
 
 	for _, param := range params {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -193,7 +193,7 @@ func (n krpAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *http
 	}
 
 	if len(params) == 0 {
-		return nil
+		return allAttrs
 	}
 
 	for _, param := range params {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -143,10 +143,21 @@ func (n krpAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *http
 	allAttrs := []authorizer.Attributes{}
 
 	if n.authzConfig.ResourceAttributes != nil {
-		if n.authzConfig.Rewrites != nil && n.authzConfig.Rewrites.ByQueryParameter != nil && n.authzConfig.Rewrites.ByQueryParameter.Name != "" {
-			params, ok := r.URL.Query()[n.authzConfig.Rewrites.ByQueryParameter.Name]
-			if !ok {
-				return nil
+		if n.authzConfig.Rewrites != nil {
+			params := []string{}
+			if n.authzConfig.Rewrites.ByQueryParameter != nil && n.authzConfig.Rewrites.ByQueryParameter.Name != "" {
+				if ps, ok := r.URL.Query()[n.authzConfig.Rewrites.ByQueryParameter.Name]; ok {
+					params = append(params, ps...)
+				}
+			}
+			if n.authzConfig.Rewrites.ByHTTPHeader != nil && n.authzConfig.Rewrites.ByHTTPHeader.Name != "" {
+				if p := r.Header.Get(n.authzConfig.Rewrites.ByHTTPHeader.Name); p != "" {
+					params = append(params, p)
+				}
+			}
+
+			if len(params) == 0 {
+				return []authorizer.Attributes{}
 			}
 
 			for _, param := range params {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -205,7 +205,6 @@ func TestGeneratingAuthorizerAttributes(t *testing.T) {
 			},
 		},
 	}
-
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
 			t.Log(c.req.URL.Query())

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -110,7 +110,7 @@ func TestGeneratingAuthorizerAttributes(t *testing.T) {
 			},
 		},
 		{
-			"without rewrites",
+			"without rewrites config",
 			&authz.Config{ResourceAttributes: &authz.ResourceAttributes{Namespace: "tenant1", APIVersion: "v1", Resource: "namespace", Subresource: "metrics"}},
 			createRequest(nil, nil),
 			[]authorizer.Attributes{
@@ -128,7 +128,7 @@ func TestGeneratingAuthorizerAttributes(t *testing.T) {
 			},
 		},
 		{
-			"with query param rewrites",
+			"with query param rewrites config",
 			&authz.Config{
 				Rewrites:           &authz.SubjectAccessReviewRewrites{ByQueryParameter: &authz.QueryParameterRewriteConfig{Name: "namespace"}},
 				ResourceAttributes: &authz.ResourceAttributes{Namespace: "{{ .Value }}", APIVersion: "v1", Resource: "namespace", Subresource: "metrics"},
@@ -149,7 +149,16 @@ func TestGeneratingAuthorizerAttributes(t *testing.T) {
 			},
 		},
 		{
-			"with http header rewrites",
+			"with query param rewrites config but missing URL query",
+			&authz.Config{
+				Rewrites:           &authz.SubjectAccessReviewRewrites{ByQueryParameter: &authz.QueryParameterRewriteConfig{Name: "namespace"}},
+				ResourceAttributes: &authz.ResourceAttributes{Namespace: "{{ .Value }}", APIVersion: "v1", Resource: "namespace", Subresource: "metrics"},
+			},
+			createRequest(nil, nil),
+			nil,
+		},
+		{
+			"with http header rewrites config",
 			&authz.Config{
 				Rewrites:           &authz.SubjectAccessReviewRewrites{ByHTTPHeader: &authz.HTTPHeaderRewriteConfig{Name: "namespace"}},
 				ResourceAttributes: &authz.ResourceAttributes{Namespace: "{{ .Value }}", APIVersion: "v1", Resource: "namespace", Subresource: "metrics"},
@@ -170,7 +179,16 @@ func TestGeneratingAuthorizerAttributes(t *testing.T) {
 			},
 		},
 		{
-			"with http header and query param rewrites",
+			"with http header rewrites config but missing header",
+			&authz.Config{
+				Rewrites:           &authz.SubjectAccessReviewRewrites{ByQueryParameter: &authz.QueryParameterRewriteConfig{Name: "namespace"}},
+				ResourceAttributes: &authz.ResourceAttributes{Namespace: "{{ .Value }}", APIVersion: "v1", Resource: "namespace", Subresource: "metrics"},
+			},
+			createRequest(nil, nil),
+			nil,
+		},
+		{
+			"with http header and query param rewrites config",
 			&authz.Config{
 				Rewrites: &authz.SubjectAccessReviewRewrites{
 					ByHTTPHeader:     &authz.HTTPHeaderRewriteConfig{Name: "namespace"},

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/brancz/kube-rbac-proxy/pkg/authn"
 	"github.com/brancz/kube-rbac-proxy/pkg/authz"
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/request/bearertoken"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -80,6 +81,158 @@ func TestProxyWithOIDCSupport(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGeneratingAuthorizerAttributes(t *testing.T) {
+	cases := []struct {
+		desc     string
+		authzCfg *authz.Config
+		req      *http.Request
+		expected []authorizer.Attributes
+	}{
+		{
+			"without resource attributes and rewrites",
+			&authz.Config{},
+			createRequest(nil, nil),
+			[]authorizer.Attributes{
+				authorizer.AttributesRecord{
+					User:            nil,
+					Verb:            "get",
+					Namespace:       "",
+					APIGroup:        "",
+					APIVersion:      "",
+					Resource:        "",
+					Subresource:     "",
+					Name:            "",
+					ResourceRequest: false,
+					Path:            "/accounts",
+				},
+			},
+		},
+		{
+			"without rewrites",
+			&authz.Config{ResourceAttributes: &authz.ResourceAttributes{Namespace: "tenant1", APIVersion: "v1", Resource: "namespace", Subresource: "metrics"}},
+			createRequest(nil, nil),
+			[]authorizer.Attributes{
+				authorizer.AttributesRecord{
+					User:            nil,
+					Verb:            "get",
+					Namespace:       "tenant1",
+					APIGroup:        "",
+					APIVersion:      "v1",
+					Resource:        "namespace",
+					Subresource:     "metrics",
+					Name:            "",
+					ResourceRequest: true,
+				},
+			},
+		},
+		{
+			"with query param rewrites",
+			&authz.Config{
+				Rewrites:           &authz.SubjectAccessReviewRewrites{ByQueryParameter: &authz.QueryParameterRewriteConfig{Name: "namespace"}},
+				ResourceAttributes: &authz.ResourceAttributes{Namespace: "{{ .Value }}", APIVersion: "v1", Resource: "namespace", Subresource: "metrics"},
+			},
+			createRequest(map[string]string{"namespace": "tenant1"}, nil),
+			[]authorizer.Attributes{
+				authorizer.AttributesRecord{
+					User:            nil,
+					Verb:            "get",
+					Namespace:       "tenant1",
+					APIGroup:        "",
+					APIVersion:      "v1",
+					Resource:        "namespace",
+					Subresource:     "metrics",
+					Name:            "",
+					ResourceRequest: true,
+				},
+			},
+		},
+		{
+			"with http header rewrites",
+			&authz.Config{
+				Rewrites:           &authz.SubjectAccessReviewRewrites{ByHTTPHeader: &authz.HTTPHeaderRewriteConfig{Name: "namespace"}},
+				ResourceAttributes: &authz.ResourceAttributes{Namespace: "{{ .Value }}", APIVersion: "v1", Resource: "namespace", Subresource: "metrics"},
+			},
+			createRequest(nil, map[string]string{"namespace": "tenant1"}),
+			[]authorizer.Attributes{
+				authorizer.AttributesRecord{
+					User:            nil,
+					Verb:            "get",
+					Namespace:       "tenant1",
+					APIGroup:        "",
+					APIVersion:      "v1",
+					Resource:        "namespace",
+					Subresource:     "metrics",
+					Name:            "",
+					ResourceRequest: true,
+				},
+			},
+		},
+		{
+			"with http header and query param rewrites",
+			&authz.Config{
+				Rewrites: &authz.SubjectAccessReviewRewrites{
+					ByHTTPHeader:     &authz.HTTPHeaderRewriteConfig{Name: "namespace"},
+					ByQueryParameter: &authz.QueryParameterRewriteConfig{Name: "namespace"},
+				},
+				ResourceAttributes: &authz.ResourceAttributes{Namespace: "{{ .Value }}", APIVersion: "v1", Resource: "namespace", Subresource: "metrics"},
+			},
+			createRequest(map[string]string{"namespace": "tenant1"}, map[string]string{"namespace": "tenant2"}),
+			[]authorizer.Attributes{
+				authorizer.AttributesRecord{
+					User:            nil,
+					Verb:            "get",
+					Namespace:       "tenant1",
+					APIGroup:        "",
+					APIVersion:      "v1",
+					Resource:        "namespace",
+					Subresource:     "metrics",
+					Name:            "",
+					ResourceRequest: true,
+				},
+				authorizer.AttributesRecord{
+					User:            nil,
+					Verb:            "get",
+					Namespace:       "tenant2",
+					APIGroup:        "",
+					APIVersion:      "v1",
+					Resource:        "namespace",
+					Subresource:     "metrics",
+					Name:            "",
+					ResourceRequest: true,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			t.Log(c.req.URL.Query())
+			n := krpAuthorizerAttributesGetter{authzConfig: c.authzCfg}
+			res := n.GetRequestAttributes(nil, c.req)
+			if !cmp.Equal(res, c.expected) {
+				t.Errorf("Generated authorizer attributes are not correct. Expected %v, recieved %v", c.expected, res)
+			}
+		})
+	}
+}
+
+func createRequest(queryParams, headers map[string]string) *http.Request {
+	r := httptest.NewRequest("GET", "/accounts", nil)
+	if queryParams != nil {
+		q := r.URL.Query()
+		for k, v := range queryParams {
+			q.Add(k, v)
+		}
+		r.URL.RawQuery = q.Encode()
+	}
+	if headers != nil {
+		for k, v := range headers {
+			r.Header.Set(k, v)
+		}
+	}
+	return r
 }
 
 func setupTestScenario() []testCase {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -205,6 +205,7 @@ func TestGeneratingAuthorizerAttributes(t *testing.T) {
 			},
 		},
 	}
+
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
 			t.Log(c.req.URL.Query())


### PR DESCRIPTION
**Description**
This PR extends the SubjectAccessReviews rewrite functionality by allowing to rewrite the attributes using a value from http header.

**Motivation**
I would like to put kube-rbac-proxy in front of Loki (https://grafana.com/docs/loki/latest/). Loki, when deployed in multi-tenant mode, requires X-Scope-OrgID header containing the tenantID. In my case, the tenantID is just the namespace and so I could check if a given user/SA has access to a particular resource in a given namespace provided in the X-Scope-OrgID header. This way I could separate the logs on a per namespace basis.