### PR TITLE
Improve CI coverage and fix existing failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,13 +3,47 @@ name: Go
 on: [push, pull_request]
 
 env:
-  VERSION: 1.15.x
   QUAY_PATH: quay.io/brancz/kube-rbac-proxy
+  go-version: '1.15'
   kind-version: 'v0.9.0'
 
 jobs:
-  create-cluster:
+  check-license:
     runs-on: ubuntu-latest
+    name: Check license
+    steps:
+    - uses: actions/checkout@v2
+    - run: make check-license
+  generate:
+    runs-on: ubuntu-latest
+    name: Generate
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.go-version }}
+    - run: make generate && git diff --exit-code
+  build:
+    runs-on: ubuntu-latest
+    name: Build
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.go-version }}
+    - run: make build
+  unit-tests:
+    runs-on: ubuntu-latest
+    name: Unit tests
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.go-version }}
+    - run: make test
+  e2e-tests:
+    runs-on: ubuntu-latest
+    name: E2E tests
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -31,11 +65,31 @@ jobs:
         VERSION=local make container
         kind load docker-image ${QUAY_PATH}:local
         make test-e2e
-    - name: Login and push to Quay
-      if: github.event_name == 'push'
-      run: |
-        docker login quay.io -u="${{ secrets.QUAY_USERNAME }}" -p="${{ secrets.QUAY_PASSWORD }}"
-        TAG="$(git rev-parse --abbrev-ref HEAD | tr / -)-$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)"
-        ID="$(docker images ${QUAY_PATH}:local --format "{{.ID}}")"
-        docker tag $ID ${QUAY_PATH}:$TAG
-        docker push ${QUAY_PATH}:$TAG
+  publish:
+    runs-on: ubuntu-latest
+    name: Publish container image to Quay
+    if: github.event_name == 'push'
+    needs:
+      - check-license
+      - generate
+      - build
+      - unit-tests
+      # Disable e2e-tests job requirement to avoid having flakes impacting
+      # image publication.
+      # This requirement should be uncommented once the flaky tests are fixed.
+      # - e2e-tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Login to Quay.io
+        uses: docker/login-actions@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Build images and push
+        run: |
+          TAG="$(git rev-parse --abbrev-ref HEAD | tr / -)-$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)"
+          ID="$(docker images ${QUAY_PATH}:local --format "{{.ID}}")"
+          docker tag $ID ${QUAY_PATH}:$TAG
+          docker push ${QUAY_PATH}:$TAG

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ env.go-version }}
-    - run: make test
+    - run: make test-unit
   e2e-tests:
     runs-on: ubuntu-latest
     name: E2E tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _output/
 manifest-tool
 .idea/*
+tmp

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOARCH?=$(shell go env GOARCH)
 OUT_DIR=_output
 BIN?=kube-rbac-proxy
 VERSION?=$(shell cat VERSION)-$(shell git rev-parse --short HEAD)
-PKGS=$(shell go list ./... )
+PKGS=$(shell go list ./... | grep -v /test/e2e)
 DOCKER_REPO?=quay.io/brancz/kube-rbac-proxy
 KUBECONFIG?=$(HOME)/.kube/config
 
@@ -77,7 +77,7 @@ test:
 	# install test dependencies
 	@go test -i $(PKGS)
 	# run the tests
-	@go test  $(PKGS)
+	@go test $(PKGS)
 
 test-e2e:
 	go test -timeout 55m -v ./test/e2e/ $(TEST_RUN_ARGS) --kubeconfig=$(KUBECONFIG)

--- a/Makefile
+++ b/Makefile
@@ -77,12 +77,10 @@ run-curl-container:
 grpcc-container:
 	docker build -f ./examples/grpcc/Dockerfile -t mumoshu/grpcc:v0.0.1 .
 
-test:
-	@echo ">> running all tests"
-	# install test dependencies
-	@go test -i $(PKGS)
-	# run the tests
-	@go test $(PKGS)
+test: test-unit test-e2e
+
+test-unit:
+	go test -v -race -count=1 $(PKGS)
 
 test-e2e:
 	go test -timeout 55m -v ./test/e2e/ $(TEST_RUN_ARGS) --kubeconfig=$(KUBECONFIG)
@@ -101,4 +99,4 @@ $(TOOLING): $(TOOLS_BIN_DIR)
 	@echo Installing tools from scripts/tools.go
 	@cat scripts/tools.go | grep _ | awk -F'"' '{print $$2}' | GOBIN=$(TOOLS_BIN_DIR) xargs -tI % go install -mod=readonly -modfile=scripts/go.mod %
 
-.PHONY: all check-license crossbuild build container push push-% manifest-push curl-container test generate
+.PHONY: all check-license crossbuild build container push push-% manifest-push curl-container test test-unit test-e2e generate

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ All command line flags:
 [embedmd]:# (_output/help.txt)
 ```txt
 $ kube-rbac-proxy -h
-Usage of _output/linux/amd64/kube-rbac-proxy:
-      --add_dir_header                              If true, adds the file directory to the header
+Usage of _output/kube-rbac-proxy:
+      --add_dir_header                              If true, adds the file directory to the header of the log messages
       --allow-paths strings                         Comma-separated list of paths against which kube-rbac-proxy matches the incoming request. If the request doesn't match, kube-rbac-proxy responds with a 404 status code. If omitted, the incoming request path isn't checked. Cannot be used with --ignore-paths.
       --alsologtostderr                             log to standard error as well as files
       --auth-header-fields-enabled                  When set to true, kube-rbac-proxy adds auth-related fields to the headers of http requests sent to the upstream

--- a/examples/non-resource-url-token-request/README.md
+++ b/examples/non-resource-url-token-request/README.md
@@ -73,10 +73,12 @@ spec:
       labels:
         app: kube-rbac-proxy
     spec:
+      securityContext:
+        runAsUser: 65532
       serviceAccountName: kube-rbac-proxy
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.7.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8081/"
@@ -86,6 +88,8 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+        securityContext:
+          allowPrivilegeEscalation: false
       - name: prometheus-example-app
         image: quay.io/brancz/prometheus-example-app:v0.1.0
         args:

--- a/examples/non-resource-url-token-request/deployment.yaml
+++ b/examples/non-resource-url-token-request/deployment.yaml
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: kube-rbac-proxy
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.7.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8081/"

--- a/examples/non-resource-url/README.md
+++ b/examples/non-resource-url/README.md
@@ -73,10 +73,12 @@ spec:
       labels:
         app: kube-rbac-proxy
     spec:
+      securityContext:
+        runAsUser: 65532
       serviceAccountName: kube-rbac-proxy
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.7.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8081/"
@@ -85,6 +87,8 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+        securityContext:
+          allowPrivilegeEscalation: false
       - name: prometheus-example-app
         image: quay.io/brancz/prometheus-example-app:v0.1.0
         args:

--- a/examples/non-resource-url/deployment.yaml
+++ b/examples/non-resource-url/deployment.yaml
@@ -60,7 +60,7 @@ spec:
       serviceAccountName: kube-rbac-proxy
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.7.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8081/"

--- a/examples/non-resource-url/non-resource-url/README.md
+++ b/examples/non-resource-url/non-resource-url/README.md
@@ -73,6 +73,8 @@ spec:
       labels:
         app: kube-rbac-proxy
     spec:
+      securityContext:
+        runAsUser: 65532
       serviceAccountName: kube-rbac-proxy
       containers:
       - name: kube-rbac-proxy
@@ -85,6 +87,8 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+        securityContext:
+          allowPrivilegeEscalation: false
       - name: prometheus-example-app
         image: quay.io/brancz/prometheus-example-app:v0.1.0
         args:

--- a/examples/oidc/deployment.yaml
+++ b/examples/oidc/deployment.yaml
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: kube-rbac-proxy
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.7.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         args:
         - "--insecure-listen-address=0.0.0.0:8444"
         - "--upstream=http://127.0.0.1:8081/"

--- a/examples/resource-attributes/README.md
+++ b/examples/resource-attributes/README.md
@@ -87,10 +87,12 @@ spec:
       labels:
         app: kube-rbac-proxy
     spec:
+      securityContext:
+        runAsUser: 65532
       serviceAccountName: kube-rbac-proxy
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.7.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8081/"
@@ -103,6 +105,8 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/kube-rbac-proxy
+        securityContext:
+          allowPrivilegeEscalation: false
       - name: prometheus-example-app
         image: quay.io/brancz/prometheus-example-app:v0.1.0
         args:

--- a/examples/resource-attributes/deployment.yaml
+++ b/examples/resource-attributes/deployment.yaml
@@ -74,7 +74,7 @@ spec:
       serviceAccountName: kube-rbac-proxy
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.7.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8081/"

--- a/examples/rewrites/README.md
+++ b/examples/rewrites/README.md
@@ -89,10 +89,12 @@ spec:
       labels:
         app: kube-rbac-proxy
     spec:
+      securityContext:
+        runAsUser: 65532
       serviceAccountName: kube-rbac-proxy
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.7.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8081/"
@@ -105,6 +107,8 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/kube-rbac-proxy
+        securityContext:
+          allowPrivilegeEscalation: false
       - name: prometheus-example-app
         image: quay.io/brancz/prometheus-example-app:v0.1.0
         args:

--- a/examples/rewrites/deployment.yaml
+++ b/examples/rewrites/deployment.yaml
@@ -76,7 +76,7 @@ spec:
       serviceAccountName: kube-rbac-proxy
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.7.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8081/"

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -42,6 +42,7 @@ func TestProxyWithOIDCSupport(t *testing.T) {
 				UserFieldName:   "user",
 				GroupsFieldName: "groups",
 			},
+			Token: &authn.TokenConfig{},
 		},
 		Authorization: &authz.Config{},
 	}

--- a/pkg/tls/reloader_test.go
+++ b/pkg/tls/reloader_test.go
@@ -107,8 +107,15 @@ func TestReloader(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	// add klog flags
+	klog.InitFlags(flag.CommandLine)
+
 	var err error
 	err = flag.Set("alsologtostderr", "true")
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	err = flag.Set("v", "5")
 	if err != nil {
 		log.Fatal(err)

--- a/scripts/generate-help-txt.sh
+++ b/scripts/generate-help-txt.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 echo "$ kube-rbac-proxy -h" > _output/help.txt
-_output/linux/amd64/kube-rbac-proxy -h 2>> _output/help.txt
+_output/kube-rbac-proxy -h 2>> _output/help.txt
 exit 0

--- a/scripts/go.mod
+++ b/scripts/go.mod
@@ -1,0 +1,5 @@
+module github.com/brancz/kube-rbac-proxy/tooling
+
+go 1.14
+
+require github.com/campoy/embedmd v1.0.0

--- a/scripts/go.sum
+++ b/scripts/go.sum
@@ -1,0 +1,4 @@
+github.com/campoy/embedmd v1.0.0 h1:V4kI2qTJJLf4J29RzI/MAt2c3Bl4dQSYPuflzwFH2hY=
+github.com/campoy/embedmd v1.0.0/go.mod h1:oxyr9RCiSXg0M3VJ3ks0UGfp98BpSSGr0kpiX3MzVl8=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/scripts/tools.go
+++ b/scripts/tools.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2020 Frederic Branczyk All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//+build tools
+
+package tools
+
+import (
+	_ "github.com/campoy/embedmd"
+)


### PR DESCRIPTION
While running kube-rbac-proxy unit tests locally, I noticed that these tests were failing, so while fixing them I also improved the CI coverage so that such failures could be catch early on. These improvements include the following changes:

Split the create-cluster job into 2 seperate jobs:
- e2e-tests
- publish

Add the following ci jobs from existing Makefile rules:
- check-license
- generate
- build
- unit-tests

Adding the generate job showed failures in the generation scripts, so I fixed them as part of this PR.