### PR TITLE
.github/workflows: fix typo in publish job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Login to Quay.io
-        uses: docker/login-actions@v1
+        uses: docker/login-action@v1
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}


### PR DESCRIPTION
The following CI run failed because of a typo in the publish job: https://github.com/brancz/kube-rbac-proxy/runs/1577096032