### PR TITLE
.github/workflows: fix image publication

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,7 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
       - name: Build images and push
         run: |
+          VERSION=local make container
           TAG="$(git rev-parse --abbrev-ref HEAD | tr / -)-$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)"
           ID="$(docker images ${QUAY_PATH}:local --format "{{.ID}}")"
           docker tag $ID ${QUAY_PATH}:$TAG


### PR DESCRIPTION
There is another problem with the publish job: https://github.com/brancz/kube-rbac-proxy/runs/1589263350

While splitting the create-cluster job into the e2e-test and publish jobs, I had forgotten to duplicate the container build.