### PR TITLE
option to pass bearer token header to upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Usage of _output/kube-rbac-proxy:
       --auth-header-fields-enabled                  When set to true, kube-rbac-proxy adds auth-related fields to the headers of http requests sent to the upstream
       --auth-header-groups-field-name string        The name of the field inside a http(2) request header to tell the upstream server about the user's groups (default "x-remote-groups")
       --auth-header-groups-field-separator string   The separator string used for concatenating multiple group names in a groups header field's value (default "|")
+      --auth-header-pass-bearer                     When set to true, kube-rbac-proxy will pass Authorization header with Bearer token to the upstream
       --auth-header-user-field-name string          The name of the field inside a http(2) request header to tell the upstream server about the user's name (default "x-remote-user")
       --auth-token-audiences strings                Comma-separated list of token audiences to accept. By default a token does not have to have any specific audience. It is recommended to set a specific audience.
       --client-ca-file string                       If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.

--- a/main.go
+++ b/main.go
@@ -130,6 +130,7 @@ func main() {
 	// Auth flags
 	flagset.StringVar(&cfg.auth.Authentication.X509.ClientCAFile, "client-ca-file", "", "If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.")
 	flagset.BoolVar(&cfg.auth.Authentication.Header.Enabled, "auth-header-fields-enabled", false, "When set to true, kube-rbac-proxy adds auth-related fields to the headers of http requests sent to the upstream")
+	flagset.BoolVar(&cfg.auth.Authentication.Header.PassBearerToken, "auth-header-pass-bearer", false, "When set to true, kube-rbac-proxy will pass Authorization header with Bearer token to the upstream")
 	flagset.StringVar(&cfg.auth.Authentication.Header.UserFieldName, "auth-header-user-field-name", "x-remote-user", "The name of the field inside a http(2) request header to tell the upstream server about the user's name")
 	flagset.StringVar(&cfg.auth.Authentication.Header.GroupsFieldName, "auth-header-groups-field-name", "x-remote-groups", "The name of the field inside a http(2) request header to tell the upstream server about the user's groups")
 	flagset.StringVar(&cfg.auth.Authentication.Header.GroupSeparator, "auth-header-groups-field-separator", "|", "The separator string used for concatenating multiple group names in a groups header field's value")
@@ -354,7 +355,7 @@ func main() {
 			}
 
 			gr.Add(func() error {
-				klog.Infof("Listening insecurely on %v", cfg.insecureListenAddress)
+				klog.Infof("Listening insecurely on %v. Wohou!", cfg.insecureListenAddress)
 				return srv.Serve(l)
 			}, func(err error) {
 				if err := srv.Shutdown(context.Background()); err != nil {

--- a/main.go
+++ b/main.go
@@ -355,7 +355,7 @@ func main() {
 			}
 
 			gr.Add(func() error {
-				klog.Infof("Listening insecurely on %v. Wohou!", cfg.insecureListenAddress)
+				klog.Infof("Listening insecurely on %v.", cfg.insecureListenAddress)
 				return srv.Serve(l)
 			}, func(err error) {
 				if err := srv.Shutdown(context.Background()); err != nil {

--- a/main.go
+++ b/main.go
@@ -355,7 +355,7 @@ func main() {
 			}
 
 			gr.Add(func() error {
-				klog.Infof("Listening insecurely on %v.", cfg.insecureListenAddress)
+				klog.Infof("Listening insecurely on %v", cfg.insecureListenAddress)
 				return srv.Serve(l)
 			}, func(err error) {
 				if err := srv.Shutdown(context.Background()); err != nil {

--- a/pkg/authn/config.go
+++ b/pkg/authn/config.go
@@ -20,6 +20,8 @@ package authn
 type AuthnHeaderConfig struct {
 	// When set to true, kube-rbac-proxy adds auth-related fields to the headers of http requests sent to the upstream
 	Enabled bool
+	// When set to true, kube-rbac-proxy will pass Authorization header with Bearer token to the upstream
+	PassBearerToken bool
 	// Corresponds to the name of the field inside a http(2) request header
 	// to tell the upstream server about the user's name
 	UserFieldName string

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -61,7 +61,6 @@ func New(client clientset.Interface, config Config, authorizer authorizer.Author
 // Handle authenticates the client and authorizes the request.
 // If the authn fails, a 401 error is returned. If the authz fails, a 403 error is returned
 func (h *kubeRBACProxy) Handle(w http.ResponseWriter, req *http.Request) bool {
-
 	ctx := req.Context()
 	if len(h.Config.Authentication.Token.Audiences) > 0 {
 		ctx = authenticator.WithAudiences(ctx, h.Config.Authentication.Token.Audiences)


### PR DESCRIPTION
adds `--auth-header-pass-bearer` parameter. When enabled, kube-rbac-proxy passes Authorization header with Bearer token to the upstream application.

issue: https://github.com/brancz/kube-rbac-proxy/issues/114