### PR TITLE
add static authorization option

### DIFF
--- a/examples/static-auth/README.md
+++ b/examples/static-auth/README.md
@@ -1,0 +1,186 @@
+# Static Authorization example
+
+> Note to try this out with minikube, make sure you enable RBAC correctly. Since minikube v0.26.0 the default bootstrapper is kubeadm - which should enable RBAC by default. For older version follow the instructions [here](../minikube-rbac).
+
+RBAC differentiates in two types, that need to be authorized, resources and non-resources. A resource request authorization, could for example be, that a requesting entity needs to be authorized to perform the `get` action on a particular Kubernetes Deployment.
+
+In this example we deploy the [prometheus-example-app](https://github.com/brancz/prometheus-example-app) and want to preotect it with kube-rbac-proxy, just as detailed in the [rewrite example](../rewrite/README.md). In this example however we will avoid the recurring SubjectAccessReview requests to the api server by allowing kube-rbac-proxy to authorize these requests statically. This is configured in the file passed to the kube-rbac-proxy with the `--config-file` flag. Additionally the `--upstream` flag has to be set to configure the application that should be proxied to on successful authentication as well as authorization.
+
+The kube-rbac-proxy itself also requires RBAC access, in order to perform TokenReviews as well as SubjectAccessReviews for requests that are not statically athorized. These are the APIs available from the Kubernetes API to authenticate and then validate the authorization of an entity.
+
+```bash
+$ kubectl create -f deployment.yaml
+```
+
+The content of this manifest is:
+
+[embedmd]:# (./deployment.yaml)
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-rbac-proxy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: kube-rbac-proxy
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-rbac-proxy
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+  - subjectaccessreviews
+  verbs: ["create"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-rbac-proxy
+  name: kube-rbac-proxy
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    app: kube-rbac-proxy
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-rbac-proxy
+data:
+  config-file.yaml: |+
+    authorization:
+      rewrites:
+        byQueryParameter:
+          name: "namespace"
+      resourceAttributes:
+        apiVersion: v1
+        resource: namespace
+        subresource: metrics
+        namespace: "{{ .Value }}"
+      static:
+        - resourceRequest: true
+          resource: namespace
+          subresource: metrics
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-rbac-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-rbac-proxy
+  template:
+    metadata:
+      labels:
+        app: kube-rbac-proxy
+    spec:
+      securityContext:
+        runAsUser: 65532
+      serviceAccountName: kube-rbac-proxy
+      containers:
+      - name: kube-rbac-proxy
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8081/"
+        - "--config-file=/etc/kube-rbac-proxy/config-file.yaml"
+        - "--logtostderr=true"
+        - "--v=10"
+        ports:
+        - containerPort: 8443
+          name: https
+        volumeMounts:
+        - name: config
+          mountPath: /etc/kube-rbac-proxy
+        securityContext:
+          allowPrivilegeEscalation: false
+      - name: prometheus-example-app
+        image: quay.io/brancz/prometheus-example-app:v0.1.0
+        args:
+        - "--bind=127.0.0.1:8081"
+      volumes:
+      - name: config
+        configMap:
+          name: kube-rbac-proxy
+```
+
+Once the prometheus-example-app is up and running, we can test it. In order to test it, we deploy a Job, that performs a `curl` against the above deployment. Because it has the correct RBAC roles, the request will succeed.
+
+```bash
+$ kubectl create -f client-rbac.yaml
+```
+
+The content of this manifest is:
+
+[embedmd]:# (./client-rbac.yaml)
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: namespace-metrics
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: namespace-metrics
+rules:
+- apiGroups: [""]
+  resources:
+  - namespace/metrics
+  verbs: ["get"]
+```
+
+Now simply run
+```
+kubectl run -i -t alpine --image=alpine --restart=Never -- sh -c 'apk add curl; curl -v -s -k -H "Authorization: Bearer `cat /var/run/secrets/kubernetes.io/serviceaccount/token`" https://kube-rbac-proxy.default.svc:8443/metrics?namespace=default'
+```
+
+The full configuration setting for the static authorization feature looks like this:
+```
+  config-file.yaml: |+
+    authorization:
+      static:
+        - user:
+            name: UserName
+            groups:
+              - group1
+              - group2
+          verb: get
+          namespace: default
+          apiGroup: apps
+          resourceRequest: true
+          resource: namespace
+          subresource: metrics
+          path: /metrics
+```
+The values in the above example are just aimed at illustrating what is possible. An omitted configuration setting is interpreted as a wildcard. E.g. if a static-auth configuration omits the `user` setting, any user can be statically authorized if a request fits the remaining configuration.

--- a/examples/static-auth/client-rbac.yaml
+++ b/examples/static-auth/client-rbac.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: namespace-metrics
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: namespace-metrics
+rules:
+- apiGroups: [""]
+  resources:
+  - namespace/metrics
+  verbs: ["get"]

--- a/examples/static-auth/deployment.yaml
+++ b/examples/static-auth/deployment.yaml
@@ -1,0 +1,108 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-rbac-proxy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: kube-rbac-proxy
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-rbac-proxy
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+  - subjectaccessreviews
+  verbs: ["create"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-rbac-proxy
+  name: kube-rbac-proxy
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    app: kube-rbac-proxy
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-rbac-proxy
+data:
+  config-file.yaml: |+
+    authorization:
+      rewrites:
+        byQueryParameter:
+          name: "namespace"
+      resourceAttributes:
+        apiVersion: v1
+        resource: namespace
+        subresource: metrics
+        namespace: "{{ .Value }}"
+      static:
+        - resourceRequest: true
+          resource: namespace
+          subresource: metrics
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-rbac-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-rbac-proxy
+  template:
+    metadata:
+      labels:
+        app: kube-rbac-proxy
+    spec:
+      securityContext:
+        runAsUser: 65532
+      serviceAccountName: kube-rbac-proxy
+      containers:
+      - name: kube-rbac-proxy
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8081/"
+        - "--config-file=/etc/kube-rbac-proxy/config-file.yaml"
+        - "--logtostderr=true"
+        - "--v=10"
+        ports:
+        - containerPort: 8443
+          name: https
+        volumeMounts:
+        - name: config
+          mountPath: /etc/kube-rbac-proxy
+        securityContext:
+          allowPrivilegeEscalation: false
+      - name: prometheus-example-app
+        image: quay.io/brancz/prometheus-example-app:v0.1.0
+        args:
+        - "--bind=127.0.0.1:8081"
+      volumes:
+      - name: config
+        configMap:
+          name: kube-rbac-proxy

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
-	"k8s.io/apiserver/pkg/authentication/union"
+	"k8s.io/apiserver/pkg/authorization/union"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -199,12 +199,16 @@ func main() {
 	}
 
 	sarClient := kubeClient.AuthorizationV1().SubjectAccessReviews()
-	sarAuthorizer, err := authz.NewAuthorizer(sarClient)
+	sarAuthorizer, err := authz.NewSarAuthorizer(sarClient)
 
 	if err != nil {
 		klog.Fatalf("Failed to create sar authorizer: %v", err)
 	}
-	authorizer = union.New(
+
+	staticAuthorizer := authz.NewStaticAuthorizer(cfg.auth.Authorization.Static)
+
+	authorizer := union.New(
+		staticAuthorizer,
 		sarAuthorizer,
 	)
 

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/union"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -198,11 +199,14 @@ func main() {
 	}
 
 	sarClient := kubeClient.AuthorizationV1().SubjectAccessReviews()
-	authorizer, err := authz.NewAuthorizer(sarClient)
+	sarAuthorizer, err := authz.NewAuthorizer(sarClient)
 
 	if err != nil {
-		klog.Fatalf("Failed to create authorizer: %v", err)
+		klog.Fatalf("Failed to create sar authorizer: %v", err)
 	}
+	authorizer = union.New(
+		sarAuthorizer,
+	)
 
 	auth, err := proxy.New(kubeClient, cfg.auth, authorizer, authenticator)
 

--- a/pkg/authz/auth_test.go
+++ b/pkg/authz/auth_test.go
@@ -1,0 +1,124 @@
+/*
+￼Copyright 2021 Kube RBAC Proxy Authors rights reserved.
+￼
+￼Licensed under the Apache License, Version 2.0 (the "License");
+￼you may not use this file except in compliance with the License.
+￼You may obtain a copy of the License at
+￼
+￼    http://www.apache.org/licenses/LICENSE-2.0
+￼
+￼Unless required by applicable law or agreed to in writing, software
+￼distributed under the License is distributed on an "AS IS" BASIS,
+￼WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+￼See the License for the specific language governing permissions and
+￼limitations under the License.
+￼*/
+
+package authz
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+func TestStaticAuthorizer(t *testing.T) {
+	tests := []struct {
+		name       string
+		authorizer authorizer.Authorizer
+
+		shouldPass      []authorizer.Attributes
+		shouldNoOpinion []authorizer.Attributes
+	}{
+		{
+			name: "pathOnly",
+			authorizer: NewStaticAuthorizer([]StaticAuthorizationConfig{
+				StaticAuthorizationConfig{Path: "/metrics"},
+			}),
+			shouldPass: []authorizer.Attributes{
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "system:foo"}, Verb: "get", Path: "/metrics"},
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "system:foo"}, Verb: "update", Path: "/metrics"},
+			},
+			shouldNoOpinion: []authorizer.Attributes{
+				// wrong path
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "system:foo"}, Verb: "get", Path: "/api"},
+			},
+		},
+		{
+			name: "pathAndVerb",
+			authorizer: NewStaticAuthorizer([]StaticAuthorizationConfig{
+				StaticAuthorizationConfig{Path: "/metrics", Verb: "get"},
+			}),
+			shouldPass: []authorizer.Attributes{
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "system:foo"}, Verb: "get", Path: "/metrics"},
+			},
+			shouldNoOpinion: []authorizer.Attributes{
+				// wrong path
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "system:foo"}, Verb: "get", Path: "/api"},
+				// wrong path
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "system:foo"}, Verb: "update", Path: "/metrics"},
+			},
+		},
+		{
+			name: "resourceRequestSpecifiedTrue",
+			authorizer: NewStaticAuthorizer([]StaticAuthorizationConfig{
+				StaticAuthorizationConfig{Path: "/metrics", Verb: "get", ResourceRequest: true},
+			}),
+			shouldPass: []authorizer.Attributes{
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "system:foo"}, Verb: "get", Path: "/metrics", ResourceRequest: true},
+			},
+			shouldNoOpinion: []authorizer.Attributes{
+				// wrong resourceRequest
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "system:foo"}, Verb: "get", Path: "/metrics", ResourceRequest: false},
+			},
+		},
+		{
+			name: "resourceRequestSpecifiedFalse",
+			authorizer: NewStaticAuthorizer([]StaticAuthorizationConfig{
+				StaticAuthorizationConfig{Path: "/metrics", Verb: "get", ResourceRequest: false},
+			}),
+			shouldPass: []authorizer.Attributes{
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "system:foo"}, Verb: "get", Path: "/metrics", ResourceRequest: false},
+			},
+			shouldNoOpinion: []authorizer.Attributes{
+				// wrong resourceRequest
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "system:foo"}, Verb: "get", Path: "/metrics", ResourceRequest: true},
+			},
+		},
+		{
+			name: "resourceRequestUnspecified",
+			authorizer: NewStaticAuthorizer([]StaticAuthorizationConfig{
+				StaticAuthorizationConfig{Path: "/metrics", Verb: "get"},
+			}),
+			shouldPass: []authorizer.Attributes{
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "system:foo"}, Verb: "get", Path: "/metrics", ResourceRequest: false},
+			},
+			shouldNoOpinion: []authorizer.Attributes{
+				// Verb: get and ResourceRequest: true should be
+				// mutually exclusive
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "system:foo"}, Verb: "get", Path: "/metrics", ResourceRequest: true},
+				// wrong path
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "system:foo"}, Verb: "get", Path: "/api", ResourceRequest: true},
+				// wrong path
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "system:foo"}, Verb: "update", Path: "/metrics", ResourceRequest: false},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, attr := range tt.shouldPass {
+				if decision, _, _ := tt.authorizer.Authorize(context.Background(), attr); decision != authorizer.DecisionAllow {
+					t.Errorf("incorrectly restricted %v", attr)
+				}
+			}
+
+			for _, attr := range tt.shouldNoOpinion {
+				if decision, _, _ := tt.authorizer.Authorize(context.Background(), attr); decision != authorizer.DecisionNoOpinion {
+					t.Errorf("incorrectly opinionated %v", attr)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This add a staticAuthorizer as discussed in #110.

The config of the static authorizer is currently implemented so that any unspecified fields are interpreted as pass any. E.g if a static config is specified like so:
```
config.yaml: |-
    "authorization":
      "static": [
        {
          "path": "/metrics"
         }
      ]
```
any request to `/metrics` is allowed by the static authorizer. Likewise
```
config.yaml: |-
    "authorization":
      "static": [
        {
          "path": "/metrics"
          "verb": "get"
         }
      ]
```
is a bit more strict as it only allows `GET` on `/metrics`. I think this approach is the most flexible and given the typical scope of the rbac proxy should work fine. There is however a distinct potential for users shooting themselves in the foot.

**TODO**

- [ ] documentation

Fixes #110