### PR TITLE
Support TLS v1.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,11 +68,11 @@ manifest-push: manifest-tool
 push: crossbuild manifest-tool $(addprefix push-,$(ALL_ARCH)) manifest-push
 
 curl-container:
-	docker build -f ./examples/example-client/Dockerfile -t quay.io/brancz/krp-curl:v0.0.1 .
+	docker build -f ./examples/example-client/Dockerfile -t quay.io/brancz/krp-curl:v0.0.2 .
 
 run-curl-container:
 	@echo 'Example: curl -v -s -k -H "Authorization: Bearer `cat /var/run/secrets/kubernetes.io/serviceaccount/token`" https://kube-rbac-proxy.default.svc:8443/metrics'
-	kubectl run -i -t krp-curl --image=quay.io/brancz/krp-curl:v0.0.1 --restart=Never --command -- /bin/sh
+	kubectl run -i -t krp-curl --image=quay.io/brancz/krp-curl:v0.0.2 --restart=Never --command -- /bin/sh
 
 grpcc-container:
 	docker build -f ./examples/grpcc/Dockerfile -t mumoshu/grpcc:v0.0.1 .

--- a/examples/example-client/Dockerfile
+++ b/examples/example-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.12
 
 RUN apk add --no-cache curl
 

--- a/examples/non-resource-url-token-request/README.md
+++ b/examples/non-resource-url-token-request/README.md
@@ -144,7 +144,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: krp-curl
-        image: quay.io/brancz/krp-curl:v0.0.1
+        image: quay.io/brancz/krp-curl:v0.0.2
         command:
         - /bin/sh
         - -c
@@ -237,7 +237,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: krp-curl
-        image: quay.io/brancz/krp-curl:v0.0.1
+        image: quay.io/brancz/krp-curl:v0.0.2
 ```
 
 Then the log output should look something along the lines of:

--- a/examples/non-resource-url-token-request/client.yaml
+++ b/examples/non-resource-url-token-request/client.yaml
@@ -10,7 +10,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: krp-curl
-        image: quay.io/brancz/krp-curl:v0.0.1
+        image: quay.io/brancz/krp-curl:v0.0.2
         command:
         - /bin/sh
         - -c

--- a/examples/non-resource-url-token-request/wrong-client.yaml
+++ b/examples/non-resource-url-token-request/wrong-client.yaml
@@ -10,4 +10,4 @@ spec:
       restartPolicy: Never
       containers:
       - name: krp-curl
-        image: quay.io/brancz/krp-curl:v0.0.1
+        image: quay.io/brancz/krp-curl:v0.0.2

--- a/examples/non-resource-url/README.md
+++ b/examples/non-resource-url/README.md
@@ -142,7 +142,7 @@ spec:
     spec:
       containers:
       - name: krp-curl
-        image: quay.io/brancz/krp-curl:v0.0.1
+        image: quay.io/brancz/krp-curl:v0.0.2
       restartPolicy: Never
   backoffLimit: 4
 ```

--- a/examples/non-resource-url/client.yaml
+++ b/examples/non-resource-url/client.yaml
@@ -9,6 +9,6 @@ spec:
     spec:
       containers:
       - name: krp-curl
-        image: quay.io/brancz/krp-curl:v0.0.1
+        image: quay.io/brancz/krp-curl:v0.0.2
       restartPolicy: Never
   backoffLimit: 4

--- a/examples/non-resource-url/non-resource-url/README.md
+++ b/examples/non-resource-url/non-resource-url/README.md
@@ -142,7 +142,7 @@ spec:
     spec:
       containers:
       - name: krp-curl
-        image: quay.io/brancz/krp-curl:v0.0.1
+        image: quay.io/brancz/krp-curl:v0.0.2
       restartPolicy: Never
   backoffLimit: 4
 ```

--- a/examples/non-resource-url/non-resource-url/client.yaml
+++ b/examples/non-resource-url/non-resource-url/client.yaml
@@ -9,6 +9,6 @@ spec:
     spec:
       containers:
       - name: krp-curl
-        image: quay.io/brancz/krp-curl:v0.0.1
+        image: quay.io/brancz/krp-curl:v0.0.2
       restartPolicy: Never
   backoffLimit: 4

--- a/examples/resource-attributes/README.md
+++ b/examples/resource-attributes/README.md
@@ -165,7 +165,7 @@ spec:
     spec:
       containers:
       - name: krp-curl
-        image: quay.io/brancz/krp-curl:v0.0.1
+        image: quay.io/brancz/krp-curl:v0.0.2
       restartPolicy: Never
   backoffLimit: 4
 ```

--- a/examples/resource-attributes/client.yaml
+++ b/examples/resource-attributes/client.yaml
@@ -9,6 +9,6 @@ spec:
     spec:
       containers:
       - name: krp-curl
-        image: quay.io/brancz/krp-curl:v0.0.1
+        image: quay.io/brancz/krp-curl:v0.0.2
       restartPolicy: Never
   backoffLimit: 4

--- a/main.go
+++ b/main.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -74,19 +73,6 @@ type tlsConfig struct {
 
 type configfile struct {
 	AuthorizationConfig *authz.Config `json:"authorization,omitempty"`
-}
-
-var versions = map[string]uint16{
-	"VersionTLS10": tls.VersionTLS10,
-	"VersionTLS11": tls.VersionTLS11,
-	"VersionTLS12": tls.VersionTLS12,
-}
-
-func tlsVersion(versionName string) (uint16, error) {
-	if version, ok := versions[versionName]; ok {
-		return version, nil
-	}
-	return 0, fmt.Errorf("unknown tls version %q", versionName)
 }
 
 func main() {
@@ -291,7 +277,7 @@ func main() {
 				})
 			}
 
-			version, err := tlsVersion(cfg.tls.minVersion)
+			version, err := k8sapiflag.TLSVersion(cfg.tls.minVersion)
 			if err != nil {
 				klog.Fatalf("TLS version invalid: %v", err)
 			}

--- a/scripts/kind-load-local.sh
+++ b/scripts/kind-load-local.sh
@@ -2,4 +2,4 @@
 
 kind load docker-image quay.io/brancz/kube-rbac-proxy:local
 kind load docker-image quay.io/brancz/prometheus-example-app:v0.1.0
-kind load docker-image quay.io/brancz/krp-curl:v0.0.1
+kind load docker-image quay.io/brancz/krp-curl:v0.0.2

--- a/test/e2e/basics.go
+++ b/test/e2e/basics.go
@@ -487,7 +487,7 @@ func ClientSucceeds(client kubernetes.Interface, command string, opts *kubetest.
 	return func(ctx *kubetest.ScenarioContext) error {
 		return kubetest.RunSucceeds(
 			client,
-			"quay.io/brancz/krp-curl:v0.0.1",
+			"quay.io/brancz/krp-curl:v0.0.2",
 			"kube-rbac-proxy-client",
 			[]string{"/bin/sh", "-c", command},
 			opts,
@@ -499,7 +499,7 @@ func ClientFails(client kubernetes.Interface, command string, opts *kubetest.Run
 	return func(ctx *kubetest.ScenarioContext) error {
 		return kubetest.RunFails(
 			client,
-			"quay.io/brancz/krp-curl:v0.0.1",
+			"quay.io/brancz/krp-curl:v0.0.2",
 			"kube-rbac-proxy-client",
 			[]string{"/bin/sh", "-c", command},
 			opts,

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -54,6 +54,7 @@ func Test(t *testing.T) {
 		"TokenAudience":      testTokenAudience(suite),
 		"AllowPath":          testAllowPathsRegexp(suite),
 		"IgnorePath":         testIgnorePaths(suite),
+		"TLS":                testTLS(suite),
 	}
 
 	for name, tc := range tests {

--- a/test/e2e/tls.go
+++ b/test/e2e/tls.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2021 Frederic Branczyk All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/brancz/kube-rbac-proxy/test/kubetest"
+)
+
+func testTLS(s *kubetest.Suite) kubetest.TestSuite {
+	return func(t *testing.T) {
+		command := `curl %v --connect-timeout 5 -v -s -k --fail -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" https://kube-rbac-proxy.default.svc.cluster.local:8443/metrics`
+
+		for _, tc := range []struct {
+			name    string
+			tlsFlag string
+		}{
+			{
+				name:    "1.0",
+				tlsFlag: "--tlsv1.0",
+			},
+			{
+				name:    "1.1",
+				tlsFlag: "--tlsv1.1",
+			},
+			{
+				name:    "1.2",
+				tlsFlag: "--tlsv1.2",
+			},
+			{
+				name:    "1.3",
+				tlsFlag: "--tlsv1.3",
+			},
+		} {
+			kubetest.Scenario{
+				Name: tc.name,
+
+				Given: kubetest.Setups(
+					kubetest.CreatedManifests(
+						s.KubeClient,
+						"basics/clusterRole.yaml",
+						"basics/clusterRoleBinding.yaml",
+						"basics/deployment.yaml",
+						"basics/service.yaml",
+						"basics/serviceAccount.yaml",
+						// This adds the clients cluster role to succeed
+						"basics/clusterRole-client.yaml",
+						"basics/clusterRoleBinding-client.yaml",
+					),
+				),
+				When: kubetest.Conditions(
+					kubetest.PodsAreReady(
+						s.KubeClient,
+						1,
+						"app=kube-rbac-proxy",
+					),
+					kubetest.ServiceIsReady(
+						s.KubeClient,
+						"kube-rbac-proxy",
+					),
+				),
+				Then: kubetest.Checks(
+					ClientSucceeds(
+						s.KubeClient,
+						fmt.Sprintf(command, tc.tlsFlag),
+						nil,
+					),
+				),
+			}.Run(t)
+		}
+	}
+}


### PR DESCRIPTION
This adds support for TLS 1.3.

Note: I also updated the krp-curl image to use a TLS 1.3 enabled Alpine image version 3.12 in https://quay.io/repository/brancz/krp-curl?tag=latest&tab=tags.

cc @kakkoyun @brancz @simonpasquier 