### PR TITLE
Makefile: correctly annotate container image designated platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ $(OUT_DIR)/$(BIN)-%:
 build: $(OUT_DIR)/$(BIN)
 
 container: $(OUT_DIR)/$(BIN)-$(GOOS)-$(GOARCH) Dockerfile
-	docker build --build-arg BINARY=$(BIN)-$(GOOS)-$(GOARCH) -t $(DOCKER_REPO):$(VERSION)-$(GOARCH) .
+	docker build --platform $(GOARCH) --build-arg BINARY=$(BIN)-$(GOOS)-$(GOARCH) -t $(DOCKER_REPO):$(VERSION)-$(GOARCH) .
 ifeq ($(GOARCH), amd64)
 	docker tag $(DOCKER_REPO):$(VERSION)-$(GOARCH) $(DOCKER_REPO):$(VERSION)
 endif


### PR DESCRIPTION
This should fix the incorrectly assigned CPU architecture in container image manifests. This is mostly a cosmetic change as we set proper CPU architecture in a main virtual manifest.

Example manifest for ppc64le before this change:
```
$ manifest-tool inspect quay.io/brancz/kube-rbac-proxy:v0.9.0-ppc64le
quay.io/brancz/kube-rbac-proxy:v0.9.0-ppc64le: manifest type: application/vnd.docker.distribution.manifest.v2+json
      Digest: sha256:56673d4eed7952068952ba84219ffc6693496a2e4fef57ea9bd776fb430fb6a3
Architecture: amd64
          OS: linux
    # Layers: 2
      layer 1: digest = sha256:5dea5ec2316d4a067b946b15c3c4f140b4f2ad607e73e9bc41b673ee5ebb99a3
      layer 2: digest = sha256:ea0eb814dc9409f25a39a903ad26b0e1d137f7fbfc3e61be8adf8dddb2d2ede2
```

After this change:
```
$ manifest-tool inspect quay.io/paulfantom/kube-rbac-proxy:better-arch-2021-04-28-561752e9-ppc64le
quay.io/paulfantom/kube-rbac-proxy:better-arch-2021-04-28-561752e9-ppc64le: manifest type: application/vnd.docker.distribution.manifest.v2+json
      Digest: sha256:e24c5afd19b69d4770e2780913128c217623663a718d06189db5c8313c007721
Architecture: ppc64le
          OS: linux
    # Layers: 2
      layer 1: digest = sha256:6e9c11b56e44f7f50a9868e2f481dc7f539ad6d77a71de7e9758683bf26282dc
      layer 2: digest = sha256:e6eba0c2a36ce4e43da3df5a80c41f9034eace684811f1498e9a08c43e27dcd8
```

As you can see `Architecture` field is filed correctly.

/cc @s-urbaniak 