### PR TITLE
Revert "Makefile: correctly annotate container image designated platform"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ $(OUT_DIR)/$(BIN)-%:
 build: $(OUT_DIR)/$(BIN)
 
 container: $(OUT_DIR)/$(BIN)-$(GOOS)-$(GOARCH) Dockerfile
-	docker build --platform $(GOARCH) --build-arg BINARY=$(BIN)-$(GOOS)-$(GOARCH) -t $(DOCKER_REPO):$(VERSION)-$(GOARCH) .
+	docker build --build-arg BINARY=$(BIN)-$(GOOS)-$(GOARCH) -t $(DOCKER_REPO):$(VERSION)-$(GOARCH) .
 ifeq ($(GOARCH), amd64)
 	docker tag $(DOCKER_REPO):$(VERSION)-$(GOARCH) $(DOCKER_REPO):$(VERSION)
 endif


### PR DESCRIPTION
Reverts brancz/kube-rbac-proxy#124 as it broke image builds https://github.com/brancz/kube-rbac-proxy/runs/2525412745?check_suite_focus=true

cc @paulfantom 