### PR TITLE
Prevent panics on client-cert authenticated requests

### DIFF
--- a/pkg/authn/delegating.go
+++ b/pkg/authn/delegating.go
@@ -42,19 +42,20 @@ func NewDelegatingAuthenticator(client authenticationclient.TokenReviewInterface
 		p   *dynamiccertificates.DynamicFileCAContent
 		err error
 	)
+
+	authenticatorConfig := authenticatorfactory.DelegatingAuthenticatorConfig{
+		Anonymous:               false, // always require authentication
+		CacheTTL:                2 * time.Minute,
+		TokenAccessReviewClient: client,
+		APIAudiences:            authenticator.Audiences(authn.Token.Audiences),
+	}
+
 	if len(authn.X509.ClientCAFile) > 0 {
 		p, err = dynamiccertificates.NewDynamicCAContentFromFile("client-ca", authn.X509.ClientCAFile)
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	authenticatorConfig := authenticatorfactory.DelegatingAuthenticatorConfig{
-		Anonymous:                          false, // always require authentication
-		CacheTTL:                           2 * time.Minute,
-		ClientCertificateCAContentProvider: p,
-		TokenAccessReviewClient:            client,
-		APIAudiences:                       authenticator.Audiences(authn.Token.Audiences),
+		authenticatorConfig.ClientCertificateCAContentProvider = p
 	}
 
 	authenticator, _, err := authenticatorConfig.New()


### PR DESCRIPTION
Setting a nil-value typed object in the `DelegatingAuthenticatorConfig`
will cause the generic logic to still evaluate is as non-nil since
Golang does not consider `(*type)(nil)` as `nil` in `== nil` comparison
unless `type == nil`, too.

This leads to a setup of an x509 authenticator that attempts to call
`VerifyOptions` on a nil object.

fixes https://github.com/brancz/kube-rbac-proxy/issues/131