### PR TITLE
allow path patterns in --allow-paths and --ignore-paths

### DIFF
--- a/test/e2e/allowpaths/deployment.yaml
+++ b/test/e2e/allowpaths/deployment.yaml
@@ -20,7 +20,7 @@ spec:
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8081/"
-            - "--allow-paths=/metrics"
+            - "--allow-paths=/metrics,/api/v1/label/*/values"
             - "--logtostderr=true"
             - "--v=10"
           ports:

--- a/test/e2e/basics.go
+++ b/test/e2e/basics.go
@@ -355,6 +355,11 @@ func testAllowPathsRegexp(s *kubetest.Suite) kubetest.TestSuite {
 					fmt.Sprintf(command, "/", 404, 404),
 					nil,
 				),
+				ClientSucceeds(
+					s.KubeClient,
+					fmt.Sprintf(command, "/api/v1/label/name", 404, 404),
+					nil,
+				),
 			),
 		}.Run(t)
 
@@ -392,6 +397,11 @@ func testAllowPathsRegexp(s *kubetest.Suite) kubetest.TestSuite {
 				ClientSucceeds(
 					s.KubeClient,
 					fmt.Sprintf(command, "/metrics", 200, 200),
+					nil,
+				),
+				ClientSucceeds(
+					s.KubeClient,
+					fmt.Sprintf(command, "/api/v1/label/job/values", 200, 200),
 					nil,
 				),
 			),
@@ -439,6 +449,11 @@ func testIgnorePaths(s *kubetest.Suite) kubetest.TestSuite {
 					fmt.Sprintf(commandWithoutAuth, "/metrics", 200, 200),
 					nil,
 				),
+				ClientSucceeds(
+					s.KubeClient,
+					fmt.Sprintf(commandWithoutAuth, "/api/v1/labels", 200, 200),
+					nil,
+				),
 			),
 		}.Run(t)
 
@@ -476,6 +491,11 @@ func testIgnorePaths(s *kubetest.Suite) kubetest.TestSuite {
 				ClientSucceeds(
 					s.KubeClient,
 					fmt.Sprintf(commandWithoutAuth, "/", 401, 401),
+					nil,
+				),
+				ClientSucceeds(
+					s.KubeClient,
+					fmt.Sprintf(commandWithoutAuth, "/api/v1/label/job/values", 401, 401),
 					nil,
 				),
 			),

--- a/test/e2e/ignorepaths/deployment.yaml
+++ b/test/e2e/ignorepaths/deployment.yaml
@@ -20,7 +20,7 @@ spec:
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8081/"
-            - "--ignore-paths=/metrics"
+            - "--ignore-paths=/metrics,/api/v1/*"
             - "--logtostderr=true"
             - "--v=10"
           ports:


### PR DESCRIPTION
This pull request make it possible to use URL patterns matching.
For example, we can use --allow-paths="/pre/fix1/*" to allow URL such as "/pre/fix1/AAA", "/pre/fix1/BBB"

We intent to make it possible to proxy requests using URL suffixes delimited by slashes as a method to pass arguments, such as [this uses case](https://issues.redhat.com/browse/MON-1695) to pass through query of label values to Prometheus. The URL can be /api/v1/label/<name>/values. Because keeping an exhaust list of labels' names is both time-costing and complicated especially when new labels are created during runtime. So we believe allowing pattern match for URL is a good solution.