### PR TITLE
.github/workflows: enable golangci-lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,15 @@ jobs:
       with:
         go-version: ${{ env.go-version }}
     - run: make generate && git diff --exit-code
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint
+    steps:
+    - uses: actions/checkout@v2
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: latest
   build:
     runs-on: ubuntu-latest
     name: Build

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,3 @@
+run:
+  skip-dirs:
+    - test/

--- a/main.go
+++ b/main.go
@@ -134,7 +134,10 @@ func main() {
 	//Kubeconfig flag
 	flagset.StringVar(&cfg.kubeconfigLocation, "kubeconfig", "", "Path to a kubeconfig file, specifying how to connect to the API server. If unset, in-cluster configuration will be used")
 
-	flagset.Parse(os.Args[1:])
+	err := flagset.Parse(os.Args[1:])
+	if err != nil {
+		klog.Fatalf("Failed to parse CLI flags: %v", err)
+	}
 	kcfg := initKubeConfig(cfg.kubeconfigLocation)
 
 	upstreamURL, err := url.Parse(cfg.upstream)
@@ -365,7 +368,7 @@ func main() {
 		}
 	}
 	{
-		sig := make(chan os.Signal)
+		sig := make(chan os.Signal, 1)
 		gr.Add(func() error {
 			signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 			<-sig

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -82,7 +82,7 @@ func (h *kubeRBACProxy) Handle(w http.ResponseWriter, req *http.Request) bool {
 	// Get authorization attributes
 	allAttrs := h.authorizerAttributesGetter.GetRequestAttributes(u.User, req)
 	if len(allAttrs) == 0 {
-		msg := fmt.Sprintf("Bad Request. The request or configuration is malformed.")
+		msg := "Bad Request. The request or configuration is malformed."
 		klog.V(2).Info(msg)
 		http.Error(w, msg, http.StatusBadRequest)
 		return false
@@ -259,6 +259,9 @@ func (c *Config) DeepCopy() *Config {
 func templateWithValue(templateString, value string) string {
 	tmpl, _ := template.New("valueTemplate").Parse(templateString)
 	out := bytes.NewBuffer(nil)
-	tmpl.Execute(out, struct{ Value string }{Value: value})
+	err := tmpl.Execute(out, struct{ Value string }{Value: value})
+	if err != nil {
+		return ""
+	}
 	return out.String()
 }

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -246,10 +246,8 @@ func createRequest(queryParams, headers map[string]string) *http.Request {
 		}
 		r.URL.RawQuery = q.Encode()
 	}
-	if headers != nil {
-		for k, v := range headers {
-			r.Header.Set(k, v)
-		}
+	for k, v := range headers {
+		r.Header.Set(k, v)
 	}
 	return r
 }

--- a/pkg/tls/reloader_test.go
+++ b/pkg/tls/reloader_test.go
@@ -193,9 +193,12 @@ func newSelfSignedCert(hostname string) stepFunc {
 		}
 
 		certPath, err := writeTempFile("cert", certBytes)
+		if err != nil {
+			t.Fatalf("error writing cert data: %v", err)
+		}
 		keyPath, err := writeTempFile("key", keyBytes)
 		if err != nil {
-			t.Fatalf("error writing cert/key data: %v", err)
+			t.Fatalf("error writing key data: %v", err)
 		}
 
 		s.certPath = certPath


### PR DESCRIPTION
A bit different approach than proposed in #134 as linter is added only in CI, but this would also catch issues like one from #131 without needing to manage tooling dependency.

Fixes https://github.com/brancz/kube-rbac-proxy/issues/134

cc @s-urbaniak 