### PR TITLE
chore: move --upstream-force-h2c out of --insecure-listen-address #139

### DIFF
--- a/scripts/kind-load-local.sh
+++ b/scripts/kind-load-local.sh
@@ -2,4 +2,5 @@
 
 kind load docker-image quay.io/brancz/kube-rbac-proxy:local
 kind load docker-image quay.io/brancz/prometheus-example-app:v0.1.0
+kind load docker-image quay.io/brancz/prometheus-example-app:v0.4.0
 kind load docker-image quay.io/brancz/krp-curl:v0.0.2

--- a/test/e2e/h2c-upstream/clusterRole-client.yaml
+++ b/test/e2e/h2c-upstream/clusterRole-client.yaml
@@ -1,0 +1,7 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: metrics
+rules:
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]

--- a/test/e2e/h2c-upstream/clusterRole.yaml
+++ b/test/e2e/h2c-upstream/clusterRole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-rbac-proxy
+  namespace: default
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources:
+      - tokenreviews
+    verbs: ["create"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources:
+      - subjectaccessreviews
+    verbs: ["create"]

--- a/test/e2e/h2c-upstream/clusterRoleBinding-client.yaml
+++ b/test/e2e/h2c-upstream/clusterRoleBinding-client.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metrics
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: default

--- a/test/e2e/h2c-upstream/clusterRoleBinding.yaml
+++ b/test/e2e/h2c-upstream/clusterRoleBinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-rbac-proxy
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-rbac-proxy
+subjects:
+  - kind: ServiceAccount
+    name: kube-rbac-proxy
+    namespace: default

--- a/test/e2e/h2c-upstream/deployment.yaml
+++ b/test/e2e/h2c-upstream/deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-rbac-proxy
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-rbac-proxy
+  template:
+    metadata:
+      labels:
+        app: kube-rbac-proxy
+    spec:
+      serviceAccountName: kube-rbac-proxy
+      containers:
+        - name: kube-rbac-proxy
+          image: quay.io/brancz/kube-rbac-proxy:local
+          args:
+            - "--secure-listen-address=0.0.0.0:8443"
+            - "--upstream=http://127.0.0.1:8081/"
+            - "--upstream-force-h2c=true"
+            - "--logtostderr=true"
+            - "--v=10"
+          ports:
+            - containerPort: 8443
+              name: https
+        - name: prometheus-example-app
+          image: quay.io/brancz/prometheus-example-app:v0.4.0
+          args:
+            - "--bind=127.0.0.1:8081"
+            - "--h2c=true"

--- a/test/e2e/h2c-upstream/service.yaml
+++ b/test/e2e/h2c-upstream/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-rbac-proxy
+  name: kube-rbac-proxy
+  namespace: default
+spec:
+  ports:
+    - name: https
+      port: 8443
+      targetPort: https
+  selector:
+    app: kube-rbac-proxy

--- a/test/e2e/h2c-upstream/serviceAccount.yaml
+++ b/test/e2e/h2c-upstream/serviceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-rbac-proxy
+  namespace: default

--- a/test/e2e/h2c_upstream.go
+++ b/test/e2e/h2c_upstream.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2017 Frederic Branczyk All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/brancz/kube-rbac-proxy/test/kubetest"
+)
+
+func testH2CUpstream(s *kubetest.Suite) kubetest.TestSuite {
+	return func(t *testing.T) {
+		command := `curl --connect-timeout 5 -v -s -k --fail -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" https://kube-rbac-proxy.default.svc.cluster.local:8443/metrics`
+
+		kubetest.Scenario{
+			Name: "With H2C Upstream",
+
+			Given: kubetest.Setups(
+				kubetest.CreatedManifests(
+					s.KubeClient,
+					"h2c-upstream/clusterRole.yaml",
+					"h2c-upstream/clusterRoleBinding.yaml",
+					"h2c-upstream/deployment.yaml",
+					"h2c-upstream/service.yaml",
+					"h2c-upstream/serviceAccount.yaml",
+					"h2c-upstream/clusterRole-client.yaml",
+					"h2c-upstream/clusterRoleBinding-client.yaml",
+				),
+			),
+			When: kubetest.Conditions(
+				kubetest.PodsAreReady(
+					s.KubeClient,
+					1,
+					"app=kube-rbac-proxy",
+				),
+				kubetest.ServiceIsReady(
+					s.KubeClient,
+					"kube-rbac-proxy",
+				),
+			),
+			Then: kubetest.Checks(
+				ClientSucceeds(
+					s.KubeClient,
+					command,
+					nil,
+				),
+			),
+		}.Run(t)
+	}
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -50,6 +50,7 @@ func TestMain(m *testing.M) {
 func Test(t *testing.T) {
 	tests := map[string]kubetest.TestSuite{
 		"Basics":             testBasics(suite),
+		"H2CUpstream":        testH2CUpstream(suite),
 		"ClientCertificates": testClientCertificates(suite),
 		"TokenAudience":      testTokenAudience(suite),
 		"AllowPath":          testAllowPathsRegexp(suite),


### PR DESCRIPTION
Upstream-force-h2c is a flag for upstream, while insecure-listen-address is for the proxy endpoint. Both can work
separately. One use case is having a secure terminating endpoint with kube-rbac-proxy while having an insecure upstream.

Signed-off-by: Andy Librian <andylibrian@gmail.com>

ref: #139 