### PR TITLE
config: allow multiple configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Usage of _output/kube-rbac-proxy:
       --auth-header-user-field-name string          The name of the field inside a http(2) request header to tell the upstream server about the user's name (default "x-remote-user")
       --auth-token-audiences strings                Comma-separated list of token audiences to accept. By default a token does not have to have any specific audience. It is recommended to set a specific audience.
       --client-ca-file string                       If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.
-      --config-file string                          Configuration file to configure kube-rbac-proxy.
+      --config-file strings                         Configuration file to configure kube-rbac-proxy. Can be specified multiple times to configure multiple resource authorizations.
       --ignore-paths strings                        Comma-separated list of paths against which kube-rbac-proxy will proxy without performing an authentication or authorization check. Cannot be used with --allow-paths.
       --insecure-listen-address string              The address the kube-rbac-proxy HTTP server should listen on.
       --kubeconfig string                           Path to a kubeconfig file, specifying how to connect to the API server. If unset, in-cluster configuration will be used

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -57,6 +57,7 @@ func Test(t *testing.T) {
 		"IgnorePath":         testIgnorePaths(suite),
 		"TLS":                testTLS(suite),
 		"StaticAuthorizer":   testStaticAuthorizer(suite),
+		"MultipleConfigs":    testMultipleConfigs(suite),
 	}
 
 	for name, tc := range tests {

--- a/test/e2e/multiple-configs/clusterRole-client.yaml
+++ b/test/e2e/multiple-configs/clusterRole-client.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metrics
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get"]

--- a/test/e2e/multiple-configs/clusterRole.yaml
+++ b/test/e2e/multiple-configs/clusterRole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-rbac-proxy
+  namespace: default
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources:
+      - tokenreviews
+    verbs: ["create"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources:
+      - subjectaccessreviews
+    verbs: ["create"]

--- a/test/e2e/multiple-configs/clusterRoleBinding-client.yaml
+++ b/test/e2e/multiple-configs/clusterRoleBinding-client.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metrics
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: default

--- a/test/e2e/multiple-configs/clusterRoleBinding.yaml
+++ b/test/e2e/multiple-configs/clusterRoleBinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-rbac-proxy
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-rbac-proxy
+subjects:
+  - kind: ServiceAccount
+    name: kube-rbac-proxy
+    namespace: default

--- a/test/e2e/multiple-configs/configmap-resource.yaml
+++ b/test/e2e/multiple-configs/configmap-resource.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-rbac-proxy
+data:
+  config-file1.yaml: |+
+    authorization:
+      rewrites:
+        byQueryParameter:
+          name: "namespace"
+      resourceAttributes:
+        resource: namespaces
+        subresource: metrics
+        namespace: "{{ .Value }}"
+      static:
+        - user:
+            name: system:serviceaccount:default:default
+          resourceRequest: true
+          resource: namespaces
+          subresource: metrics
+          namespace: default
+          verbs: get
+  config-file2.yaml: |+
+    authorization:
+      resourceAttributes:
+        resource: pods

--- a/test/e2e/multiple-configs/deployment.yaml
+++ b/test/e2e/multiple-configs/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-rbac-proxy
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-rbac-proxy
+  template:
+    metadata:
+      labels:
+        app: kube-rbac-proxy
+    spec:
+      securityContext:
+        runAsUser: 65532
+      serviceAccountName: kube-rbac-proxy
+      containers:
+        - name: kube-rbac-proxy
+          image: quay.io/brancz/kube-rbac-proxy:local
+          args:
+            - "--secure-listen-address=0.0.0.0:8443"
+            - "--upstream=http://127.0.0.1:8081/"
+            - "--config-file=/etc/kube-rbac-proxy/config-file1.yaml"
+            - "--config-file=/etc/kube-rbac-proxy/config-file2.yaml"
+            - "--logtostderr=true"
+            - "--v=10"
+          ports:
+            - containerPort: 8443
+              name: https
+          volumeMounts:
+            - name: config
+              mountPath: /etc/kube-rbac-proxy
+          securityContext:
+            allowPrivilegeEscalation: false
+        - name: prometheus-example-app
+          image: quay.io/brancz/prometheus-example-app:v0.1.0
+          args:
+            - "--bind=127.0.0.1:8081"
+      volumes:
+        - name: config
+          configMap:
+            name: kube-rbac-proxy

--- a/test/e2e/multiple-configs/service.yaml
+++ b/test/e2e/multiple-configs/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-rbac-proxy
+  name: kube-rbac-proxy
+  namespace: default
+spec:
+  ports:
+    - name: https
+      port: 8443
+      targetPort: https
+  selector:
+    app: kube-rbac-proxy

--- a/test/e2e/multiple-configs/serviceAccount.yaml
+++ b/test/e2e/multiple-configs/serviceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-rbac-proxy
+  namespace: default

--- a/test/e2e/multiple_configs.go
+++ b/test/e2e/multiple_configs.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2017 Frederic Branczyk All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/brancz/kube-rbac-proxy/test/kubetest"
+)
+
+func testMultipleConfigs(s *kubetest.Suite) kubetest.TestSuite {
+	return func(t *testing.T) {
+		command := `curl --connect-timeout 5 -v -s -k --fail -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" https://kube-rbac-proxy.default.svc.cluster.local:8443%v`
+
+		for _, tc := range []struct {
+			name  string
+			given []kubetest.Setup
+			check []kubetest.Check
+		}{
+			{
+				name: "RBAC + correct namespace",
+				given: []kubetest.Setup{
+					kubetest.CreatedManifests(
+						s.KubeClient,
+						"multiple-configs/configmap-resource.yaml",
+						"multiple-configs/clusterRole.yaml",
+						"multiple-configs/clusterRoleBinding.yaml",
+						"multiple-configs/clusterRole-client.yaml",
+						"multiple-configs/clusterRoleBinding-client.yaml",
+						"multiple-configs/deployment.yaml",
+						"multiple-configs/service.yaml",
+						"multiple-configs/serviceAccount.yaml",
+					),
+				},
+				check: []kubetest.Check{
+					ClientSucceeds(
+						s.KubeClient,
+						fmt.Sprintf(command, "/metrics?namespace=default"),
+						nil,
+					),
+				},
+			},
+			{
+				name: "no RBAC + correct namespace",
+				given: []kubetest.Setup{
+					kubetest.CreatedManifests(
+						s.KubeClient,
+						"multiple-configs/configmap-resource.yaml",
+						"multiple-configs/clusterRole.yaml",
+						"multiple-configs/clusterRoleBinding.yaml",
+						"multiple-configs/deployment.yaml",
+						"multiple-configs/service.yaml",
+						"multiple-configs/serviceAccount.yaml",
+					),
+				},
+				check: []kubetest.Check{
+					ClientFails(
+						s.KubeClient,
+						fmt.Sprintf(command, "/metrics?namespace=default"),
+						nil,
+					),
+				},
+			},
+			{
+				name: "RBAC + wrong namespace",
+				given: []kubetest.Setup{
+					kubetest.CreatedManifests(
+						s.KubeClient,
+						"multiple-configs/configmap-resource.yaml",
+						"multiple-configs/clusterRole.yaml",
+						"multiple-configs/clusterRoleBinding.yaml",
+						"multiple-configs/clusterRole-client.yaml",
+						"multiple-configs/clusterRoleBinding-client.yaml",
+						"multiple-configs/deployment.yaml",
+						"multiple-configs/service.yaml",
+						"multiple-configs/serviceAccount.yaml",
+					),
+				},
+				check: []kubetest.Check{
+					ClientFails(
+						s.KubeClient,
+						fmt.Sprintf(command, "/metrics?namespace=forbidden"),
+						nil,
+					),
+				},
+			},
+			{
+				name: "no RBAC + wrong namespace",
+				given: []kubetest.Setup{
+					kubetest.CreatedManifests(
+						s.KubeClient,
+						"multiple-configs/configmap-resource.yaml",
+						"multiple-configs/clusterRole.yaml",
+						"multiple-configs/clusterRoleBinding.yaml",
+						"multiple-configs/deployment.yaml",
+						"multiple-configs/service.yaml",
+						"multiple-configs/serviceAccount.yaml",
+					),
+				},
+				check: []kubetest.Check{
+					ClientFails(
+						s.KubeClient,
+						fmt.Sprintf(command, "/metrics?namespace=forbidden"),
+						nil,
+					),
+				},
+			},
+		} {
+			kubetest.Scenario{
+				Name:  tc.name,
+				Given: kubetest.Setups(tc.given...),
+				When: kubetest.Conditions(
+					kubetest.PodsAreReady(
+						s.KubeClient,
+						1,
+						"app=kube-rbac-proxy",
+					),
+					kubetest.ServiceIsReady(
+						s.KubeClient,
+						"kube-rbac-proxy",
+					),
+				),
+				Then: kubetest.Checks(tc.check...),
+			}.Run(t)
+		}
+	}
+}


### PR DESCRIPTION
This commit fixes issue #154 by enabling the user to repeat the
`--config-file` flag multiple times to specify multiple configurations.
Doing so, allows the user to declare that the krp should, e.g., enforce
multiple resource attributes.

fixes: #154

cc @simonpasquier @s-urbaniak 

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>