### PR TITLE
initTransport() uses http.DefaultTransport for initialization.

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -22,9 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
-	"time"
 )
 
 func initTransport(upstreamCAFile string) (http.RoundTripper, error) {
@@ -42,20 +40,9 @@ func initTransport(upstreamCAFile string) (http.RoundTripper, error) {
 		return nil, errors.New("error parsing upstream CA certificate")
 	}
 
-	// http.Transport sourced from go 1.10.7
-	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-			DualStack: true,
-		}).DialContext,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-		TLSClientConfig:       &tls.Config{RootCAs: roots},
-	}
+	transport := (http.DefaultTransport.(*http.Transport)).Clone()
+	transport.TLSClientConfig = &tls.Config{RootCAs: roots}
+	transport.ForceAttemptHTTP2 = false
 
 	return transport, nil
 }


### PR DESCRIPTION
This PR let initTransport() uses http.DefaultTransport for initialization, avoiding potential discrepancy on the default HTTP transport initial value between kube-rbac-proxy and golang `net/http` package.