### PR TITLE
check all headers, go version bump

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   QUAY_PATH: quay.io/brancz/kube-rbac-proxy
-  go-version: '1.17.6'
+  go-version: '1.17.9'
   kind-version: 'v0.11.0'
 
 jobs:

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -216,49 +216,6 @@ func (n krpAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *http
 	return allAttrs
 }
 
-// DeepCopy of Proxy Configuration
-func (c *Config) DeepCopy() *Config {
-	res := &Config{
-		Authentication: &authn.AuthnConfig{},
-	}
-
-	if c.Authentication != nil {
-		res.Authentication = &authn.AuthnConfig{}
-
-		if c.Authentication.X509 != nil {
-			res.Authentication.X509 = &authn.X509Config{
-				ClientCAFile: c.Authentication.X509.ClientCAFile,
-			}
-		}
-
-		if c.Authentication.Header != nil {
-			res.Authentication.Header = &authn.AuthnHeaderConfig{
-				Enabled:         c.Authentication.Header.Enabled,
-				UserFieldName:   c.Authentication.Header.UserFieldName,
-				GroupsFieldName: c.Authentication.Header.GroupsFieldName,
-				GroupSeparator:  c.Authentication.Header.GroupSeparator,
-			}
-		}
-	}
-
-	if c.Authorization != nil {
-		if c.Authorization.ResourceAttributes != nil {
-			res.Authorization = &authz.Config{
-				ResourceAttributes: &authz.ResourceAttributes{
-					Namespace:   c.Authorization.ResourceAttributes.Namespace,
-					APIGroup:    c.Authorization.ResourceAttributes.APIGroup,
-					APIVersion:  c.Authorization.ResourceAttributes.APIVersion,
-					Resource:    c.Authorization.ResourceAttributes.Resource,
-					Subresource: c.Authorization.ResourceAttributes.Subresource,
-					Name:        c.Authorization.ResourceAttributes.Name,
-				},
-			}
-		}
-	}
-
-	return res
-}
-
 func templateWithValue(templateString, value string) string {
 	tmpl, _ := template.New("valueTemplate").Parse(templateString)
 	out := bytes.NewBuffer(nil)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"net/textproto"
 	"strings"
 	"text/template"
 
@@ -187,8 +188,10 @@ func (n krpAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *http
 		}
 	}
 	if n.authzConfig.Rewrites.ByHTTPHeader != nil && n.authzConfig.Rewrites.ByHTTPHeader.Name != "" {
-		if p := r.Header.Get(n.authzConfig.Rewrites.ByHTTPHeader.Name); p != "" {
-			params = append(params, p)
+		mimeHeader := textproto.MIMEHeader(r.Header)
+		mimeKey := textproto.CanonicalMIMEHeaderKey(n.authzConfig.Rewrites.ByHTTPHeader.Name)
+		if ps, ok := mimeHeader[mimeKey]; ok {
+			params = append(params, ps...)
 		}
 	}
 


### PR DESCRIPTION
## What

- set go-version on build workflow to 1.17.9
- remove dead code: DeepCopy
- check for all headers, not just the first entry, when creating AttributesRecords

## Why

- go version 1.17.8 and 1.17.9 have security fixes
- unused code is bad code
- don't give the impression that a second header is checked, even though it isn't

Signed-off-by: Krzysztof Ostrowski <kostrows@redhat.com>