### PR TITLE
Minor Pre-Acceptance: Set default method, return 500s on broken path regex.

### DIFF
--- a/main.go
+++ b/main.go
@@ -265,6 +265,11 @@ func main() {
 		for _, pathAllowed := range cfg.allowPaths {
 			found, err = path.Match(pathAllowed, req.URL.Path)
 			if err != nil {
+				http.Error(
+					w,
+					http.StatusText(http.StatusInternalServerError),
+					http.StatusInternalServerError,
+				)
 				return
 			}
 			if found {
@@ -280,6 +285,11 @@ func main() {
 		for _, pathIgnored := range cfg.ignorePaths {
 			ignorePathFound, err = path.Match(pathIgnored, req.URL.Path)
 			if err != nil {
+				http.Error(
+					w,
+					http.StatusText(http.StatusInternalServerError),
+					http.StatusInternalServerError,
+				)
 				return
 			}
 			if ignorePathFound {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -127,7 +127,7 @@ type krpAuthorizerAttributesGetter struct {
 
 // GetRequestAttributes populates authorizer attributes for the requests to kube-rbac-proxy.
 func (n krpAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *http.Request) []authorizer.Attributes {
-	apiVerb := ""
+	apiVerb := "*"
 	switch r.Method {
 	case "POST":
 		apiVerb = "create"


### PR DESCRIPTION
## What

- Add explicit default method for `resourceAttributes`. The behavior shouldn't change.
- Return an internal error on misconfigured regex. Shouldn't change behavior. As it is checked during parsing.

## Why

- An unspecified method could make it harder to understand, why a SAR gets rejected.
- It is safer to handle the error case with a 500, even thought is currently can't happen.

## Ref

https://github.com/brancz/kube-rbac-proxy/issues/169