### PR TITLE
Tests e2e reduce abstraction

### DIFF
--- a/test/e2e/basics.go
+++ b/test/e2e/basics.go
@@ -36,7 +36,7 @@ func testBasics(client kubernetes.Interface) kubetest.TestSuite {
 				I fail with my request
 			`,
 
-			Given: kubetest.Setups(
+			Given: kubetest.Actions(
 				kubetest.CreatedManifests(
 					client,
 					"basics/clusterRole.yaml",
@@ -46,7 +46,7 @@ func testBasics(client kubernetes.Interface) kubetest.TestSuite {
 					"basics/serviceAccount.yaml",
 				),
 			),
-			When: kubetest.Conditions(
+			When: kubetest.Actions(
 				kubetest.PodsAreReady(
 					client,
 					1,
@@ -57,7 +57,7 @@ func testBasics(client kubernetes.Interface) kubetest.TestSuite {
 					"kube-rbac-proxy",
 				),
 			),
-			Then: kubetest.Checks(
+			Then: kubetest.Actions(
 				ClientFails(
 					client,
 					command,
@@ -73,7 +73,7 @@ func testBasics(client kubernetes.Interface) kubetest.TestSuite {
 				I succeed with my request
 			`,
 
-			Given: kubetest.Setups(
+			Given: kubetest.Actions(
 				kubetest.CreatedManifests(
 					client,
 					"basics/clusterRole.yaml",
@@ -86,7 +86,7 @@ func testBasics(client kubernetes.Interface) kubetest.TestSuite {
 					"basics/clusterRoleBinding-client.yaml",
 				),
 			),
-			When: kubetest.Conditions(
+			When: kubetest.Actions(
 				kubetest.PodsAreReady(
 					client,
 					1,
@@ -97,7 +97,7 @@ func testBasics(client kubernetes.Interface) kubetest.TestSuite {
 					"kube-rbac-proxy",
 				),
 			),
-			Then: kubetest.Checks(
+			Then: kubetest.Actions(
 				ClientSucceeds(
 					client,
 					command,
@@ -119,7 +119,7 @@ func testTokenAudience(client kubernetes.Interface) kubetest.TestSuite {
 				I fail with my request
 			`,
 
-			Given: kubetest.Setups(
+			Given: kubetest.Actions(
 				kubetest.CreatedManifests(
 					client,
 					"tokenrequest/clusterRole.yaml",
@@ -131,7 +131,7 @@ func testTokenAudience(client kubernetes.Interface) kubetest.TestSuite {
 					"tokenrequest/clusterRoleBinding-client.yaml",
 				),
 			),
-			When: kubetest.Conditions(
+			When: kubetest.Actions(
 				kubetest.PodsAreReady(
 					client,
 					1,
@@ -142,7 +142,7 @@ func testTokenAudience(client kubernetes.Interface) kubetest.TestSuite {
 					"kube-rbac-proxy",
 				),
 			),
-			Then: kubetest.Checks(
+			Then: kubetest.Actions(
 				ClientFails(
 					client,
 					command,
@@ -158,7 +158,7 @@ func testTokenAudience(client kubernetes.Interface) kubetest.TestSuite {
 				I succeed with my request
 			`,
 
-			Given: kubetest.Setups(
+			Given: kubetest.Actions(
 				kubetest.CreatedManifests(
 					client,
 					"tokenrequest/clusterRole.yaml",
@@ -170,7 +170,7 @@ func testTokenAudience(client kubernetes.Interface) kubetest.TestSuite {
 					"tokenrequest/clusterRoleBinding-client.yaml",
 				),
 			),
-			When: kubetest.Conditions(
+			When: kubetest.Actions(
 				kubetest.PodsAreReady(
 					client,
 					1,
@@ -181,7 +181,7 @@ func testTokenAudience(client kubernetes.Interface) kubetest.TestSuite {
 					"kube-rbac-proxy",
 				),
 			),
-			Then: kubetest.Checks(
+			Then: kubetest.Actions(
 				ClientSucceeds(
 					client,
 					command,
@@ -203,7 +203,7 @@ func testClientCertificates(client kubernetes.Interface) kubetest.TestSuite {
 				I fail with my request
 			`,
 
-			Given: kubetest.Setups(
+			Given: kubetest.Actions(
 				kubetest.CreatedManifests(
 					client,
 					"clientcertificates/certificate.yaml",
@@ -214,7 +214,7 @@ func testClientCertificates(client kubernetes.Interface) kubetest.TestSuite {
 					"clientcertificates/serviceAccount.yaml",
 				),
 			),
-			When: kubetest.Conditions(
+			When: kubetest.Actions(
 				kubetest.PodsAreReady(
 					client,
 					1,
@@ -225,7 +225,7 @@ func testClientCertificates(client kubernetes.Interface) kubetest.TestSuite {
 					"kube-rbac-proxy",
 				),
 			),
-			Then: kubetest.Checks(
+			Then: kubetest.Actions(
 				ClientFails(
 					client,
 					command,
@@ -241,7 +241,7 @@ func testClientCertificates(client kubernetes.Interface) kubetest.TestSuite {
 				I succeed with my request
 			`,
 
-			Given: kubetest.Setups(
+			Given: kubetest.Actions(
 				kubetest.CreatedManifests(
 					client,
 					"clientcertificates/certificate.yaml",
@@ -254,7 +254,7 @@ func testClientCertificates(client kubernetes.Interface) kubetest.TestSuite {
 					"clientcertificates/clusterRoleBinding-client.yaml",
 				),
 			),
-			When: kubetest.Conditions(
+			When: kubetest.Actions(
 				kubetest.PodsAreReady(
 					client,
 					1,
@@ -265,7 +265,7 @@ func testClientCertificates(client kubernetes.Interface) kubetest.TestSuite {
 					"kube-rbac-proxy",
 				),
 			),
-			Then: kubetest.Checks(
+			Then: kubetest.Actions(
 				ClientSucceeds(
 					client,
 					command,
@@ -281,7 +281,7 @@ func testClientCertificates(client kubernetes.Interface) kubetest.TestSuite {
 				I fail with my request
 			`,
 
-			Given: kubetest.Setups(
+			Given: kubetest.Actions(
 				kubetest.CreatedManifests(
 					client,
 					"clientcertificates/certificate.yaml",
@@ -294,7 +294,7 @@ func testClientCertificates(client kubernetes.Interface) kubetest.TestSuite {
 					"clientcertificates/clusterRoleBinding-client.yaml",
 				),
 			),
-			When: kubetest.Conditions(
+			When: kubetest.Actions(
 				kubetest.PodsAreReady(
 					client,
 					1,
@@ -305,7 +305,7 @@ func testClientCertificates(client kubernetes.Interface) kubetest.TestSuite {
 					"kube-rbac-proxy",
 				),
 			),
-			Then: kubetest.Checks(
+			Then: kubetest.Actions(
 				ClientFails(
 					client,
 					command,
@@ -327,7 +327,7 @@ func testAllowPathsRegexp(client kubernetes.Interface) kubetest.TestSuite {
 				I get a 404 response when requesting a path which isn't allowed by kube-rbac-proxy
 			`,
 
-			Given: kubetest.Setups(
+			Given: kubetest.Actions(
 				kubetest.CreatedManifests(
 					client,
 					"allowpaths/clusterRole.yaml",
@@ -339,7 +339,7 @@ func testAllowPathsRegexp(client kubernetes.Interface) kubetest.TestSuite {
 					"allowpaths/clusterRoleBinding-client.yaml",
 				),
 			),
-			When: kubetest.Conditions(
+			When: kubetest.Actions(
 				kubetest.PodsAreReady(
 					client,
 					1,
@@ -350,7 +350,7 @@ func testAllowPathsRegexp(client kubernetes.Interface) kubetest.TestSuite {
 					"kube-rbac-proxy",
 				),
 			),
-			Then: kubetest.Checks(
+			Then: kubetest.Actions(
 				ClientSucceeds(
 					client,
 					fmt.Sprintf(command, "/", 404, 404),
@@ -371,7 +371,7 @@ func testAllowPathsRegexp(client kubernetes.Interface) kubetest.TestSuite {
 				I succeed with my request for a path that is allowed
 			`,
 
-			Given: kubetest.Setups(
+			Given: kubetest.Actions(
 				kubetest.CreatedManifests(
 					client,
 					"allowpaths/clusterRole.yaml",
@@ -383,7 +383,7 @@ func testAllowPathsRegexp(client kubernetes.Interface) kubetest.TestSuite {
 					"allowpaths/clusterRoleBinding-client.yaml",
 				),
 			),
-			When: kubetest.Conditions(
+			When: kubetest.Actions(
 				kubetest.PodsAreReady(
 					client,
 					1,
@@ -394,7 +394,7 @@ func testAllowPathsRegexp(client kubernetes.Interface) kubetest.TestSuite {
 					"kube-rbac-proxy",
 				),
 			),
-			Then: kubetest.Checks(
+			Then: kubetest.Actions(
 				ClientSucceeds(
 					client,
 					fmt.Sprintf(command, "/metrics", 200, 200),
@@ -421,7 +421,7 @@ func testIgnorePaths(client kubernetes.Interface) kubetest.TestSuite {
 				I get a 200 response when requesting a path included in ignorePaths
 			`,
 
-			Given: kubetest.Setups(
+			Given: kubetest.Actions(
 				kubetest.CreatedManifests(
 					client,
 					"ignorepaths/clusterRole.yaml",
@@ -433,7 +433,7 @@ func testIgnorePaths(client kubernetes.Interface) kubetest.TestSuite {
 					"ignorepaths/clusterRoleBinding-client.yaml",
 				),
 			),
-			When: kubetest.Conditions(
+			When: kubetest.Actions(
 				kubetest.PodsAreReady(
 					client,
 					1,
@@ -444,7 +444,7 @@ func testIgnorePaths(client kubernetes.Interface) kubetest.TestSuite {
 					"kube-rbac-proxy",
 				),
 			),
-			Then: kubetest.Checks(
+			Then: kubetest.Actions(
 				ClientSucceeds(
 					client,
 					fmt.Sprintf(commandWithoutAuth, "/metrics", 200, 200),
@@ -465,7 +465,7 @@ func testIgnorePaths(client kubernetes.Interface) kubetest.TestSuite {
 				I get a 401 response when requesting a path not included in ignorePaths
 			`,
 
-			Given: kubetest.Setups(
+			Given: kubetest.Actions(
 				kubetest.CreatedManifests(
 					client,
 					"ignorepaths/clusterRole.yaml",
@@ -477,7 +477,7 @@ func testIgnorePaths(client kubernetes.Interface) kubetest.TestSuite {
 					"ignorepaths/clusterRoleBinding-client.yaml",
 				),
 			),
-			When: kubetest.Conditions(
+			When: kubetest.Actions(
 				kubetest.PodsAreReady(
 					client,
 					1,
@@ -488,7 +488,7 @@ func testIgnorePaths(client kubernetes.Interface) kubetest.TestSuite {
 					"kube-rbac-proxy",
 				),
 			),
-			Then: kubetest.Checks(
+			Then: kubetest.Actions(
 				ClientSucceeds(
 					client,
 					fmt.Sprintf(commandWithoutAuth, "/", 401, 401),
@@ -504,7 +504,7 @@ func testIgnorePaths(client kubernetes.Interface) kubetest.TestSuite {
 	}
 }
 
-func ClientSucceeds(client kubernetes.Interface, command string, opts *kubetest.RunOptions) kubetest.Check {
+func ClientSucceeds(client kubernetes.Interface, command string, opts *kubetest.RunOptions) kubetest.Action {
 	return func(ctx *kubetest.ScenarioContext) error {
 		return kubetest.RunSucceeds(
 			client,
@@ -516,7 +516,7 @@ func ClientSucceeds(client kubernetes.Interface, command string, opts *kubetest.
 	}
 }
 
-func ClientFails(client kubernetes.Interface, command string, opts *kubetest.RunOptions) kubetest.Check {
+func ClientFails(client kubernetes.Interface, command string, opts *kubetest.RunOptions) kubetest.Action {
 	return func(ctx *kubetest.ScenarioContext) error {
 		return kubetest.RunFails(
 			client,

--- a/test/e2e/basics.go
+++ b/test/e2e/basics.go
@@ -20,11 +20,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/brancz/kube-rbac-proxy/test/kubetest"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/brancz/kube-rbac-proxy/test/kubetest"
 )
 
-func testBasics(s *kubetest.Suite) kubetest.TestSuite {
+func testBasics(client kubernetes.Interface) kubetest.TestSuite {
 	return func(t *testing.T) {
 		command := `curl --connect-timeout 5 -v -s -k --fail -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" https://kube-rbac-proxy.default.svc.cluster.local:8443/metrics`
 
@@ -37,7 +38,7 @@ func testBasics(s *kubetest.Suite) kubetest.TestSuite {
 
 			Given: kubetest.Setups(
 				kubetest.CreatedManifests(
-					s.KubeClient,
+					client,
 					"basics/clusterRole.yaml",
 					"basics/clusterRoleBinding.yaml",
 					"basics/deployment.yaml",
@@ -47,18 +48,18 @@ func testBasics(s *kubetest.Suite) kubetest.TestSuite {
 			),
 			When: kubetest.Conditions(
 				kubetest.PodsAreReady(
-					s.KubeClient,
+					client,
 					1,
 					"app=kube-rbac-proxy",
 				),
 				kubetest.ServiceIsReady(
-					s.KubeClient,
+					client,
 					"kube-rbac-proxy",
 				),
 			),
 			Then: kubetest.Checks(
 				ClientFails(
-					s.KubeClient,
+					client,
 					command,
 					nil,
 				),
@@ -74,7 +75,7 @@ func testBasics(s *kubetest.Suite) kubetest.TestSuite {
 
 			Given: kubetest.Setups(
 				kubetest.CreatedManifests(
-					s.KubeClient,
+					client,
 					"basics/clusterRole.yaml",
 					"basics/clusterRoleBinding.yaml",
 					"basics/deployment.yaml",
@@ -87,18 +88,18 @@ func testBasics(s *kubetest.Suite) kubetest.TestSuite {
 			),
 			When: kubetest.Conditions(
 				kubetest.PodsAreReady(
-					s.KubeClient,
+					client,
 					1,
 					"app=kube-rbac-proxy",
 				),
 				kubetest.ServiceIsReady(
-					s.KubeClient,
+					client,
 					"kube-rbac-proxy",
 				),
 			),
 			Then: kubetest.Checks(
 				ClientSucceeds(
-					s.KubeClient,
+					client,
 					command,
 					nil,
 				),
@@ -107,7 +108,7 @@ func testBasics(s *kubetest.Suite) kubetest.TestSuite {
 	}
 }
 
-func testTokenAudience(s *kubetest.Suite) kubetest.TestSuite {
+func testTokenAudience(client kubernetes.Interface) kubetest.TestSuite {
 	return func(t *testing.T) {
 		command := `curl --connect-timeout 5 -v -s -k --fail -H "Authorization: Bearer $(cat /var/run/secrets/tokens/requestedtoken)" https://kube-rbac-proxy.default.svc.cluster.local:8443/metrics`
 
@@ -120,7 +121,7 @@ func testTokenAudience(s *kubetest.Suite) kubetest.TestSuite {
 
 			Given: kubetest.Setups(
 				kubetest.CreatedManifests(
-					s.KubeClient,
+					client,
 					"tokenrequest/clusterRole.yaml",
 					"tokenrequest/clusterRoleBinding.yaml",
 					"tokenrequest/deployment.yaml",
@@ -132,18 +133,18 @@ func testTokenAudience(s *kubetest.Suite) kubetest.TestSuite {
 			),
 			When: kubetest.Conditions(
 				kubetest.PodsAreReady(
-					s.KubeClient,
+					client,
 					1,
 					"app=kube-rbac-proxy",
 				),
 				kubetest.ServiceIsReady(
-					s.KubeClient,
+					client,
 					"kube-rbac-proxy",
 				),
 			),
 			Then: kubetest.Checks(
 				ClientFails(
-					s.KubeClient,
+					client,
 					command,
 					&kubetest.RunOptions{TokenAudience: "wrong-audience"},
 				),
@@ -159,7 +160,7 @@ func testTokenAudience(s *kubetest.Suite) kubetest.TestSuite {
 
 			Given: kubetest.Setups(
 				kubetest.CreatedManifests(
-					s.KubeClient,
+					client,
 					"tokenrequest/clusterRole.yaml",
 					"tokenrequest/clusterRoleBinding.yaml",
 					"tokenrequest/deployment.yaml",
@@ -171,18 +172,18 @@ func testTokenAudience(s *kubetest.Suite) kubetest.TestSuite {
 			),
 			When: kubetest.Conditions(
 				kubetest.PodsAreReady(
-					s.KubeClient,
+					client,
 					1,
 					"app=kube-rbac-proxy",
 				),
 				kubetest.ServiceIsReady(
-					s.KubeClient,
+					client,
 					"kube-rbac-proxy",
 				),
 			),
 			Then: kubetest.Checks(
 				ClientSucceeds(
-					s.KubeClient,
+					client,
 					command,
 					&kubetest.RunOptions{TokenAudience: "kube-rbac-proxy"},
 				),
@@ -191,7 +192,7 @@ func testTokenAudience(s *kubetest.Suite) kubetest.TestSuite {
 	}
 }
 
-func testClientCertificates(s *kubetest.Suite) kubetest.TestSuite {
+func testClientCertificates(client kubernetes.Interface) kubetest.TestSuite {
 	return func(t *testing.T) {
 		command := `curl --connect-timeout 5 -v -s -k --fail --cert /certs/tls.crt --key /certs/tls.key https://kube-rbac-proxy.default.svc.cluster.local:8443/metrics`
 
@@ -204,7 +205,7 @@ func testClientCertificates(s *kubetest.Suite) kubetest.TestSuite {
 
 			Given: kubetest.Setups(
 				kubetest.CreatedManifests(
-					s.KubeClient,
+					client,
 					"clientcertificates/certificate.yaml",
 					"clientcertificates/clusterRole.yaml",
 					"clientcertificates/clusterRoleBinding.yaml",
@@ -215,18 +216,18 @@ func testClientCertificates(s *kubetest.Suite) kubetest.TestSuite {
 			),
 			When: kubetest.Conditions(
 				kubetest.PodsAreReady(
-					s.KubeClient,
+					client,
 					1,
 					"app=kube-rbac-proxy",
 				),
 				kubetest.ServiceIsReady(
-					s.KubeClient,
+					client,
 					"kube-rbac-proxy",
 				),
 			),
 			Then: kubetest.Checks(
 				ClientFails(
-					s.KubeClient,
+					client,
 					command,
 					&kubetest.RunOptions{ClientCertificates: true},
 				),
@@ -242,7 +243,7 @@ func testClientCertificates(s *kubetest.Suite) kubetest.TestSuite {
 
 			Given: kubetest.Setups(
 				kubetest.CreatedManifests(
-					s.KubeClient,
+					client,
 					"clientcertificates/certificate.yaml",
 					"clientcertificates/clusterRole.yaml",
 					"clientcertificates/clusterRoleBinding.yaml",
@@ -255,18 +256,18 @@ func testClientCertificates(s *kubetest.Suite) kubetest.TestSuite {
 			),
 			When: kubetest.Conditions(
 				kubetest.PodsAreReady(
-					s.KubeClient,
+					client,
 					1,
 					"app=kube-rbac-proxy",
 				),
 				kubetest.ServiceIsReady(
-					s.KubeClient,
+					client,
 					"kube-rbac-proxy",
 				),
 			),
 			Then: kubetest.Checks(
 				ClientSucceeds(
-					s.KubeClient,
+					client,
 					command,
 					&kubetest.RunOptions{ClientCertificates: true},
 				),
@@ -282,7 +283,7 @@ func testClientCertificates(s *kubetest.Suite) kubetest.TestSuite {
 
 			Given: kubetest.Setups(
 				kubetest.CreatedManifests(
-					s.KubeClient,
+					client,
 					"clientcertificates/certificate.yaml",
 					"clientcertificates/clusterRole.yaml",
 					"clientcertificates/clusterRoleBinding.yaml",
@@ -295,18 +296,18 @@ func testClientCertificates(s *kubetest.Suite) kubetest.TestSuite {
 			),
 			When: kubetest.Conditions(
 				kubetest.PodsAreReady(
-					s.KubeClient,
+					client,
 					1,
 					"app=kube-rbac-proxy",
 				),
 				kubetest.ServiceIsReady(
-					s.KubeClient,
+					client,
 					"kube-rbac-proxy",
 				),
 			),
 			Then: kubetest.Checks(
 				ClientFails(
-					s.KubeClient,
+					client,
 					command,
 					&kubetest.RunOptions{ClientCertificates: true},
 				),
@@ -315,7 +316,7 @@ func testClientCertificates(s *kubetest.Suite) kubetest.TestSuite {
 	}
 }
 
-func testAllowPathsRegexp(s *kubetest.Suite) kubetest.TestSuite {
+func testAllowPathsRegexp(client kubernetes.Interface) kubetest.TestSuite {
 	return func(t *testing.T) {
 		command := `STATUS_CODE=$(curl --connect-timeout 5 -o /dev/null -v -s -k --write-out "%%{http_code}" -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" https://kube-rbac-proxy.default.svc.cluster.local:8443%s); if [[ "$STATUS_CODE" != %d ]]; then echo "expecting %d status code, got $STATUS_CODE instead" > /proc/self/fd/2; exit 1; fi`
 
@@ -328,7 +329,7 @@ func testAllowPathsRegexp(s *kubetest.Suite) kubetest.TestSuite {
 
 			Given: kubetest.Setups(
 				kubetest.CreatedManifests(
-					s.KubeClient,
+					client,
 					"allowpaths/clusterRole.yaml",
 					"allowpaths/clusterRoleBinding.yaml",
 					"allowpaths/deployment.yaml",
@@ -340,23 +341,23 @@ func testAllowPathsRegexp(s *kubetest.Suite) kubetest.TestSuite {
 			),
 			When: kubetest.Conditions(
 				kubetest.PodsAreReady(
-					s.KubeClient,
+					client,
 					1,
 					"app=kube-rbac-proxy",
 				),
 				kubetest.ServiceIsReady(
-					s.KubeClient,
+					client,
 					"kube-rbac-proxy",
 				),
 			),
 			Then: kubetest.Checks(
 				ClientSucceeds(
-					s.KubeClient,
+					client,
 					fmt.Sprintf(command, "/", 404, 404),
 					nil,
 				),
 				ClientSucceeds(
-					s.KubeClient,
+					client,
 					fmt.Sprintf(command, "/api/v1/label/name", 404, 404),
 					nil,
 				),
@@ -372,7 +373,7 @@ func testAllowPathsRegexp(s *kubetest.Suite) kubetest.TestSuite {
 
 			Given: kubetest.Setups(
 				kubetest.CreatedManifests(
-					s.KubeClient,
+					client,
 					"allowpaths/clusterRole.yaml",
 					"allowpaths/clusterRoleBinding.yaml",
 					"allowpaths/deployment.yaml",
@@ -384,23 +385,23 @@ func testAllowPathsRegexp(s *kubetest.Suite) kubetest.TestSuite {
 			),
 			When: kubetest.Conditions(
 				kubetest.PodsAreReady(
-					s.KubeClient,
+					client,
 					1,
 					"app=kube-rbac-proxy",
 				),
 				kubetest.ServiceIsReady(
-					s.KubeClient,
+					client,
 					"kube-rbac-proxy",
 				),
 			),
 			Then: kubetest.Checks(
 				ClientSucceeds(
-					s.KubeClient,
+					client,
 					fmt.Sprintf(command, "/metrics", 200, 200),
 					nil,
 				),
 				ClientSucceeds(
-					s.KubeClient,
+					client,
 					fmt.Sprintf(command, "/api/v1/label/job/values", 200, 200),
 					nil,
 				),
@@ -409,7 +410,7 @@ func testAllowPathsRegexp(s *kubetest.Suite) kubetest.TestSuite {
 	}
 }
 
-func testIgnorePaths(s *kubetest.Suite) kubetest.TestSuite {
+func testIgnorePaths(client kubernetes.Interface) kubetest.TestSuite {
 	return func(t *testing.T) {
 		commandWithoutAuth := `STATUS_CODE=$(curl --connect-timeout 5 -o /dev/null -v -s -k --write-out "%%{http_code}" https://kube-rbac-proxy.default.svc.cluster.local:8443%s); if [[ "$STATUS_CODE" != %d ]]; then echo "expecting %d status code, got $STATUS_CODE instead" > /proc/self/fd/2; exit 1; fi`
 
@@ -422,7 +423,7 @@ func testIgnorePaths(s *kubetest.Suite) kubetest.TestSuite {
 
 			Given: kubetest.Setups(
 				kubetest.CreatedManifests(
-					s.KubeClient,
+					client,
 					"ignorepaths/clusterRole.yaml",
 					"ignorepaths/clusterRoleBinding.yaml",
 					"ignorepaths/deployment.yaml",
@@ -434,23 +435,23 @@ func testIgnorePaths(s *kubetest.Suite) kubetest.TestSuite {
 			),
 			When: kubetest.Conditions(
 				kubetest.PodsAreReady(
-					s.KubeClient,
+					client,
 					1,
 					"app=kube-rbac-proxy",
 				),
 				kubetest.ServiceIsReady(
-					s.KubeClient,
+					client,
 					"kube-rbac-proxy",
 				),
 			),
 			Then: kubetest.Checks(
 				ClientSucceeds(
-					s.KubeClient,
+					client,
 					fmt.Sprintf(commandWithoutAuth, "/metrics", 200, 200),
 					nil,
 				),
 				ClientSucceeds(
-					s.KubeClient,
+					client,
 					fmt.Sprintf(commandWithoutAuth, "/api/v1/labels", 200, 200),
 					nil,
 				),
@@ -466,7 +467,7 @@ func testIgnorePaths(s *kubetest.Suite) kubetest.TestSuite {
 
 			Given: kubetest.Setups(
 				kubetest.CreatedManifests(
-					s.KubeClient,
+					client,
 					"ignorepaths/clusterRole.yaml",
 					"ignorepaths/clusterRoleBinding.yaml",
 					"ignorepaths/deployment.yaml",
@@ -478,23 +479,23 @@ func testIgnorePaths(s *kubetest.Suite) kubetest.TestSuite {
 			),
 			When: kubetest.Conditions(
 				kubetest.PodsAreReady(
-					s.KubeClient,
+					client,
 					1,
 					"app=kube-rbac-proxy",
 				),
 				kubetest.ServiceIsReady(
-					s.KubeClient,
+					client,
 					"kube-rbac-proxy",
 				),
 			),
 			Then: kubetest.Checks(
 				ClientSucceeds(
-					s.KubeClient,
+					client,
 					fmt.Sprintf(commandWithoutAuth, "/", 401, 401),
 					nil,
 				),
 				ClientSucceeds(
-					s.KubeClient,
+					client,
 					fmt.Sprintf(commandWithoutAuth, "/api/v1/label/job/values", 401, 401),
 					nil,
 				),

--- a/test/e2e/basics.go
+++ b/test/e2e/basics.go
@@ -58,7 +58,7 @@ func testBasics(client kubernetes.Interface) kubetest.TestSuite {
 				),
 			),
 			Then: kubetest.Actions(
-				ClientFails(
+				kubetest.ClientFails(
 					client,
 					command,
 					nil,
@@ -98,7 +98,7 @@ func testBasics(client kubernetes.Interface) kubetest.TestSuite {
 				),
 			),
 			Then: kubetest.Actions(
-				ClientSucceeds(
+				kubetest.ClientSucceeds(
 					client,
 					command,
 					nil,
@@ -143,7 +143,7 @@ func testTokenAudience(client kubernetes.Interface) kubetest.TestSuite {
 				),
 			),
 			Then: kubetest.Actions(
-				ClientFails(
+				kubetest.ClientFails(
 					client,
 					command,
 					&kubetest.RunOptions{TokenAudience: "wrong-audience"},
@@ -182,7 +182,7 @@ func testTokenAudience(client kubernetes.Interface) kubetest.TestSuite {
 				),
 			),
 			Then: kubetest.Actions(
-				ClientSucceeds(
+				kubetest.ClientSucceeds(
 					client,
 					command,
 					&kubetest.RunOptions{TokenAudience: "kube-rbac-proxy"},
@@ -226,7 +226,7 @@ func testClientCertificates(client kubernetes.Interface) kubetest.TestSuite {
 				),
 			),
 			Then: kubetest.Actions(
-				ClientFails(
+				kubetest.ClientFails(
 					client,
 					command,
 					&kubetest.RunOptions{ClientCertificates: true},
@@ -266,7 +266,7 @@ func testClientCertificates(client kubernetes.Interface) kubetest.TestSuite {
 				),
 			),
 			Then: kubetest.Actions(
-				ClientSucceeds(
+				kubetest.ClientSucceeds(
 					client,
 					command,
 					&kubetest.RunOptions{ClientCertificates: true},
@@ -306,7 +306,7 @@ func testClientCertificates(client kubernetes.Interface) kubetest.TestSuite {
 				),
 			),
 			Then: kubetest.Actions(
-				ClientFails(
+				kubetest.ClientFails(
 					client,
 					command,
 					&kubetest.RunOptions{ClientCertificates: true},
@@ -351,12 +351,12 @@ func testAllowPathsRegexp(client kubernetes.Interface) kubetest.TestSuite {
 				),
 			),
 			Then: kubetest.Actions(
-				ClientSucceeds(
+				kubetest.ClientSucceeds(
 					client,
 					fmt.Sprintf(command, "/", 404, 404),
 					nil,
 				),
-				ClientSucceeds(
+				kubetest.ClientSucceeds(
 					client,
 					fmt.Sprintf(command, "/api/v1/label/name", 404, 404),
 					nil,
@@ -395,12 +395,12 @@ func testAllowPathsRegexp(client kubernetes.Interface) kubetest.TestSuite {
 				),
 			),
 			Then: kubetest.Actions(
-				ClientSucceeds(
+				kubetest.ClientSucceeds(
 					client,
 					fmt.Sprintf(command, "/metrics", 200, 200),
 					nil,
 				),
-				ClientSucceeds(
+				kubetest.ClientSucceeds(
 					client,
 					fmt.Sprintf(command, "/api/v1/label/job/values", 200, 200),
 					nil,
@@ -445,12 +445,12 @@ func testIgnorePaths(client kubernetes.Interface) kubetest.TestSuite {
 				),
 			),
 			Then: kubetest.Actions(
-				ClientSucceeds(
+				kubetest.ClientSucceeds(
 					client,
 					fmt.Sprintf(commandWithoutAuth, "/metrics", 200, 200),
 					nil,
 				),
-				ClientSucceeds(
+				kubetest.ClientSucceeds(
 					client,
 					fmt.Sprintf(commandWithoutAuth, "/api/v1/labels", 200, 200),
 					nil,
@@ -489,41 +489,17 @@ func testIgnorePaths(client kubernetes.Interface) kubetest.TestSuite {
 				),
 			),
 			Then: kubetest.Actions(
-				ClientSucceeds(
+				kubetest.ClientSucceeds(
 					client,
 					fmt.Sprintf(commandWithoutAuth, "/", 401, 401),
 					nil,
 				),
-				ClientSucceeds(
+				kubetest.ClientSucceeds(
 					client,
 					fmt.Sprintf(commandWithoutAuth, "/api/v1/label/job/values", 401, 401),
 					nil,
 				),
 			),
 		}.Run(t)
-	}
-}
-
-func ClientSucceeds(client kubernetes.Interface, command string, opts *kubetest.RunOptions) kubetest.Action {
-	return func(ctx *kubetest.ScenarioContext) error {
-		return kubetest.RunSucceeds(
-			client,
-			"quay.io/brancz/krp-curl:v0.0.2",
-			"kube-rbac-proxy-client",
-			[]string{"/bin/sh", "-c", command},
-			opts,
-		)(ctx)
-	}
-}
-
-func ClientFails(client kubernetes.Interface, command string, opts *kubetest.RunOptions) kubetest.Action {
-	return func(ctx *kubetest.ScenarioContext) error {
-		return kubetest.RunFails(
-			client,
-			"quay.io/brancz/krp-curl:v0.0.2",
-			"kube-rbac-proxy-client",
-			[]string{"/bin/sh", "-c", command},
-			opts,
-		)(ctx)
 	}
 }

--- a/test/e2e/h2c_upstream.go
+++ b/test/e2e/h2c_upstream.go
@@ -31,7 +31,7 @@ func testH2CUpstream(client kubernetes.Interface) kubetest.TestSuite {
 		kubetest.Scenario{
 			Name: "With H2C Upstream",
 
-			Given: kubetest.Setups(
+			Given: kubetest.Actions(
 				kubetest.CreatedManifests(
 					client,
 					"h2c-upstream/clusterRole.yaml",
@@ -43,7 +43,7 @@ func testH2CUpstream(client kubernetes.Interface) kubetest.TestSuite {
 					"h2c-upstream/clusterRoleBinding-client.yaml",
 				),
 			),
-			When: kubetest.Conditions(
+			When: kubetest.Actions(
 				kubetest.PodsAreReady(
 					client,
 					1,
@@ -54,7 +54,7 @@ func testH2CUpstream(client kubernetes.Interface) kubetest.TestSuite {
 					"kube-rbac-proxy",
 				),
 			),
-			Then: kubetest.Checks(
+			Then: kubetest.Actions(
 				ClientSucceeds(
 					client,
 					command,

--- a/test/e2e/h2c_upstream.go
+++ b/test/e2e/h2c_upstream.go
@@ -55,7 +55,7 @@ func testH2CUpstream(client kubernetes.Interface) kubetest.TestSuite {
 				),
 			),
 			Then: kubetest.Actions(
-				ClientSucceeds(
+				kubetest.ClientSucceeds(
 					client,
 					command,
 					nil,

--- a/test/e2e/h2c_upstream.go
+++ b/test/e2e/h2c_upstream.go
@@ -19,10 +19,12 @@ package e2e
 import (
 	"testing"
 
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/brancz/kube-rbac-proxy/test/kubetest"
 )
 
-func testH2CUpstream(s *kubetest.Suite) kubetest.TestSuite {
+func testH2CUpstream(client kubernetes.Interface) kubetest.TestSuite {
 	return func(t *testing.T) {
 		command := `curl --connect-timeout 5 -v -s -k --fail -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" https://kube-rbac-proxy.default.svc.cluster.local:8443/metrics`
 
@@ -31,7 +33,7 @@ func testH2CUpstream(s *kubetest.Suite) kubetest.TestSuite {
 
 			Given: kubetest.Setups(
 				kubetest.CreatedManifests(
-					s.KubeClient,
+					client,
 					"h2c-upstream/clusterRole.yaml",
 					"h2c-upstream/clusterRoleBinding.yaml",
 					"h2c-upstream/deployment.yaml",
@@ -43,18 +45,18 @@ func testH2CUpstream(s *kubetest.Suite) kubetest.TestSuite {
 			),
 			When: kubetest.Conditions(
 				kubetest.PodsAreReady(
-					s.KubeClient,
+					client,
 					1,
 					"app=kube-rbac-proxy",
 				),
 				kubetest.ServiceIsReady(
-					s.KubeClient,
+					client,
 					"kube-rbac-proxy",
 				),
 			),
 			Then: kubetest.Checks(
 				ClientSucceeds(
-					s.KubeClient,
+					client,
 					command,
 					nil,
 				),

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -22,12 +22,14 @@ import (
 	"os"
 	"testing"
 
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/brancz/kube-rbac-proxy/test/kubetest"
 )
 
-// Sadly there's no way to pass Suite from TestMain to Test,
+// Sadly there's no way to pass the k8s client from TestMain to Test,
 // so we need this global instance
-var suite *kubetest.Suite
+var client kubernetes.Interface
 
 // TestMain adds the kubeconfig flag to our tests
 func TestMain(m *testing.M) {
@@ -39,7 +41,7 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 
 	var err error
-	suite, err = kubetest.NewSuiteFromKubeconfig(*kubeconfig)
+	client, err = kubetest.NewClientFromKubeconfig(*kubeconfig)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -49,14 +51,14 @@ func TestMain(m *testing.M) {
 
 func Test(t *testing.T) {
 	tests := map[string]kubetest.TestSuite{
-		"Basics":             testBasics(suite),
-		"H2CUpstream":        testH2CUpstream(suite),
-		"ClientCertificates": testClientCertificates(suite),
-		"TokenAudience":      testTokenAudience(suite),
-		"AllowPath":          testAllowPathsRegexp(suite),
-		"IgnorePath":         testIgnorePaths(suite),
-		"TLS":                testTLS(suite),
-		"StaticAuthorizer":   testStaticAuthorizer(suite),
+		"Basics":             testBasics(client),
+		"H2CUpstream":        testH2CUpstream(client),
+		"ClientCertificates": testClientCertificates(client),
+		"TokenAudience":      testTokenAudience(client),
+		"AllowPath":          testAllowPathsRegexp(client),
+		"IgnorePath":         testIgnorePaths(client),
+		"TLS":                testTLS(client),
+		"StaticAuthorizer":   testStaticAuthorizer(client),
 	}
 
 	for name, tc := range tests {

--- a/test/e2e/static_authorizer.go
+++ b/test/e2e/static_authorizer.go
@@ -48,7 +48,7 @@ func testStaticAuthorizer(client kubernetes.Interface) kubetest.TestSuite {
 					),
 				),
 				check: kubetest.Actions(
-					ClientSucceeds(
+					kubetest.ClientSucceeds(
 						client,
 						fmt.Sprintf(command, "/metrics?namespace=default"),
 						nil,
@@ -69,7 +69,7 @@ func testStaticAuthorizer(client kubernetes.Interface) kubetest.TestSuite {
 					),
 				),
 				check: kubetest.Actions(
-					ClientFails(
+					kubetest.ClientFails(
 						client,
 						fmt.Sprintf(command, "/metrics?namespace=forbidden"),
 						nil,
@@ -90,7 +90,7 @@ func testStaticAuthorizer(client kubernetes.Interface) kubetest.TestSuite {
 					),
 				),
 				check: kubetest.Actions(
-					ClientSucceeds(
+					kubetest.ClientSucceeds(
 						client,
 						fmt.Sprintf(command, "/metrics"),
 						nil,
@@ -111,7 +111,7 @@ func testStaticAuthorizer(client kubernetes.Interface) kubetest.TestSuite {
 					),
 				),
 				check: kubetest.Actions(
-					ClientFails(
+					kubetest.ClientFails(
 						client,
 						fmt.Sprintf(command, "/forbidden"),
 						nil,

--- a/test/e2e/static_authorizer.go
+++ b/test/e2e/static_authorizer.go
@@ -31,12 +31,12 @@ func testStaticAuthorizer(client kubernetes.Interface) kubetest.TestSuite {
 
 		for _, tc := range []struct {
 			name  string
-			given []kubetest.Setup
-			check []kubetest.Check
+			given kubetest.Action
+			check kubetest.Action
 		}{
 			{
 				name: "resource/namespace/metrics/query rewrite/granted",
-				given: []kubetest.Setup{
+				given: kubetest.Actions(
 					kubetest.CreatedManifests(
 						client,
 						"static-auth/configmap-resource.yaml",
@@ -46,18 +46,18 @@ func testStaticAuthorizer(client kubernetes.Interface) kubetest.TestSuite {
 						"static-auth/service.yaml",
 						"static-auth/serviceAccount.yaml",
 					),
-				},
-				check: []kubetest.Check{
+				),
+				check: kubetest.Actions(
 					ClientSucceeds(
 						client,
 						fmt.Sprintf(command, "/metrics?namespace=default"),
 						nil,
 					),
-				},
+				),
 			},
 			{
 				name: "resource/namespace/metrics/query rewrite/forbidden",
-				given: []kubetest.Setup{
+				given: kubetest.Actions(
 					kubetest.CreatedManifests(
 						client,
 						"static-auth/configmap-resource.yaml",
@@ -67,18 +67,18 @@ func testStaticAuthorizer(client kubernetes.Interface) kubetest.TestSuite {
 						"static-auth/service.yaml",
 						"static-auth/serviceAccount.yaml",
 					),
-				},
-				check: []kubetest.Check{
+				),
+				check: kubetest.Actions(
 					ClientFails(
 						client,
 						fmt.Sprintf(command, "/metrics?namespace=forbidden"),
 						nil,
 					),
-				},
+				),
 			},
 			{
 				name: "non-resource/get/metrics/granted",
-				given: []kubetest.Setup{
+				given: kubetest.Actions(
 					kubetest.CreatedManifests(
 						client,
 						"static-auth/configmap-non-resource.yaml",
@@ -88,18 +88,18 @@ func testStaticAuthorizer(client kubernetes.Interface) kubetest.TestSuite {
 						"static-auth/service.yaml",
 						"static-auth/serviceAccount.yaml",
 					),
-				},
-				check: []kubetest.Check{
+				),
+				check: kubetest.Actions(
 					ClientSucceeds(
 						client,
 						fmt.Sprintf(command, "/metrics"),
 						nil,
 					),
-				},
+				),
 			},
 			{
 				name: "non-resource/get/metrics/forbidden",
-				given: []kubetest.Setup{
+				given: kubetest.Actions(
 					kubetest.CreatedManifests(
 						client,
 						"static-auth/configmap-non-resource.yaml",
@@ -109,20 +109,20 @@ func testStaticAuthorizer(client kubernetes.Interface) kubetest.TestSuite {
 						"static-auth/service.yaml",
 						"static-auth/serviceAccount.yaml",
 					),
-				},
-				check: []kubetest.Check{
+				),
+				check: kubetest.Actions(
 					ClientFails(
 						client,
 						fmt.Sprintf(command, "/forbidden"),
 						nil,
 					),
-				},
+				),
 			},
 		} {
 			kubetest.Scenario{
 				Name:  tc.name,
-				Given: kubetest.Setups(tc.given...),
-				When: kubetest.Conditions(
+				Given: kubetest.Actions(tc.given),
+				When: kubetest.Actions(
 					kubetest.PodsAreReady(
 						client,
 						1,
@@ -133,7 +133,7 @@ func testStaticAuthorizer(client kubernetes.Interface) kubetest.TestSuite {
 						"kube-rbac-proxy",
 					),
 				),
-				Then: kubetest.Checks(tc.check...),
+				Then: kubetest.Actions(tc.check),
 			}.Run(t)
 		}
 	}

--- a/test/e2e/tls.go
+++ b/test/e2e/tls.go
@@ -53,7 +53,7 @@ func testTLS(client kubernetes.Interface) kubetest.TestSuite {
 			kubetest.Scenario{
 				Name: tc.name,
 
-				Given: kubetest.Setups(
+				Given: kubetest.Actions(
 					kubetest.CreatedManifests(
 						client,
 						"basics/clusterRole.yaml",
@@ -66,7 +66,7 @@ func testTLS(client kubernetes.Interface) kubetest.TestSuite {
 						"basics/clusterRoleBinding-client.yaml",
 					),
 				),
-				When: kubetest.Conditions(
+				When: kubetest.Actions(
 					kubetest.PodsAreReady(
 						client,
 						1,
@@ -77,7 +77,7 @@ func testTLS(client kubernetes.Interface) kubetest.TestSuite {
 						"kube-rbac-proxy",
 					),
 				),
-				Then: kubetest.Checks(
+				Then: kubetest.Actions(
 					ClientSucceeds(
 						client,
 						fmt.Sprintf(command, tc.tlsFlag),

--- a/test/e2e/tls.go
+++ b/test/e2e/tls.go
@@ -20,10 +20,12 @@ import (
 	"fmt"
 	"testing"
 
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/brancz/kube-rbac-proxy/test/kubetest"
 )
 
-func testTLS(s *kubetest.Suite) kubetest.TestSuite {
+func testTLS(client kubernetes.Interface) kubetest.TestSuite {
 	return func(t *testing.T) {
 		command := `curl %v --connect-timeout 5 -v -s -k --fail -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" https://kube-rbac-proxy.default.svc.cluster.local:8443/metrics`
 
@@ -53,7 +55,7 @@ func testTLS(s *kubetest.Suite) kubetest.TestSuite {
 
 				Given: kubetest.Setups(
 					kubetest.CreatedManifests(
-						s.KubeClient,
+						client,
 						"basics/clusterRole.yaml",
 						"basics/clusterRoleBinding.yaml",
 						"basics/deployment.yaml",
@@ -66,18 +68,18 @@ func testTLS(s *kubetest.Suite) kubetest.TestSuite {
 				),
 				When: kubetest.Conditions(
 					kubetest.PodsAreReady(
-						s.KubeClient,
+						client,
 						1,
 						"app=kube-rbac-proxy",
 					),
 					kubetest.ServiceIsReady(
-						s.KubeClient,
+						client,
 						"kube-rbac-proxy",
 					),
 				),
 				Then: kubetest.Checks(
 					ClientSucceeds(
-						s.KubeClient,
+						client,
 						fmt.Sprintf(command, tc.tlsFlag),
 						nil,
 					),

--- a/test/e2e/tls.go
+++ b/test/e2e/tls.go
@@ -78,7 +78,7 @@ func testTLS(client kubernetes.Interface) kubetest.TestSuite {
 					),
 				),
 				Then: kubetest.Actions(
-					ClientSucceeds(
+					kubetest.ClientSucceeds(
 						client,
 						fmt.Sprintf(command, tc.tlsFlag),
 						nil,

--- a/test/kubetest/client.go
+++ b/test/kubetest/client.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 kube-rbac-proxy authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kubetest
 
 import "k8s.io/client-go/kubernetes"

--- a/test/kubetest/client.go
+++ b/test/kubetest/client.go
@@ -1,0 +1,27 @@
+package kubetest
+
+import "k8s.io/client-go/kubernetes"
+
+func ClientSucceeds(client kubernetes.Interface, command string, opts *RunOptions) Action {
+	return func(ctx *ScenarioContext) error {
+		return RunSucceeds(
+			client,
+			"quay.io/brancz/krp-curl:v0.0.2",
+			"kube-rbac-proxy-client",
+			[]string{"/bin/sh", "-c", command},
+			opts,
+		)(ctx)
+	}
+}
+
+func ClientFails(client kubernetes.Interface, command string, opts *RunOptions) Action {
+	return func(ctx *ScenarioContext) error {
+		return RunFails(
+			client,
+			"quay.io/brancz/krp-curl:v0.0.2",
+			"kube-rbac-proxy-client",
+			[]string{"/bin/sh", "-c", command},
+			opts,
+		)(ctx)
+	}
+}

--- a/test/kubetest/kubernetes.go
+++ b/test/kubetest/kubernetes.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func CreatedManifests(client kubernetes.Interface, paths ...string) Setup {
+func CreatedManifests(client kubernetes.Interface, paths ...string) Action {
 	return func(ctx *ScenarioContext) error {
 		for _, path := range paths {
 			content, err := ioutil.ReadFile(path)
@@ -361,26 +361,19 @@ func podRunningAndReady(pod corev1.Pod) (bool, error) {
 	return false, nil
 }
 
-func Sleep(d time.Duration) Condition {
-	return func(ctx *ScenarioContext) error {
-		time.Sleep(d)
-		return nil
-	}
-}
-
 type RunOptions struct {
 	ServiceAccount     string
 	TokenAudience      string
 	ClientCertificates bool
 }
 
-func RunSucceeds(client kubernetes.Interface, image string, name string, command []string, opts *RunOptions) Check {
+func RunSucceeds(client kubernetes.Interface, image string, name string, command []string, opts *RunOptions) Action {
 	return func(ctx *ScenarioContext) error {
 		return run(client, ctx, image, name, command, opts)
 	}
 }
 
-func RunFails(client kubernetes.Interface, image string, name string, command []string, opts *RunOptions) Check {
+func RunFails(client kubernetes.Interface, image string, name string, command []string, opts *RunOptions) Action {
 	return func(ctx *ScenarioContext) error {
 		err := run(client, ctx, image, name, command, opts)
 		if err == nil {

--- a/test/kubetest/kubernetes.go
+++ b/test/kubetest/kubernetes.go
@@ -30,7 +30,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -525,22 +524,4 @@ func run(client kubernetes.Interface, ctx *ScenarioContext, image string, name s
 	}
 
 	return nil
-}
-
-func CreateNamespace(client kubernetes.Interface, name string) error {
-	ns := &v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-	}
-
-	_, err := client.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to create namespace with name %v", name)
-	}
-	return nil
-}
-
-func DeleteNamespace(client kubernetes.Interface, name string) error {
-	return client.CoreV1().Namespaces().Delete(context.TODO(), name, metav1.DeleteOptions{})
 }

--- a/test/kubetest/kubernetes.go
+++ b/test/kubetest/kubernetes.go
@@ -105,7 +105,7 @@ func createClusterRole(client kubernetes.Interface, ctx *ScenarioContext, conten
 
 	_, err := client.RbacV1().ClusterRoles().Create(context.TODO(), cr, metav1.CreateOptions{})
 
-	ctx.AddFinalizer(func() error {
+	ctx.AddCleanUp(func() error {
 		return client.RbacV1().ClusterRoles().Delete(context.TODO(), cr.Name, metav1.DeleteOptions{})
 	})
 
@@ -122,7 +122,7 @@ func createClusterRoleBinding(client kubernetes.Interface, ctx *ScenarioContext,
 
 	_, err := client.RbacV1().ClusterRoleBindings().Create(context.TODO(), crb, metav1.CreateOptions{})
 
-	ctx.AddFinalizer(func() error {
+	ctx.AddCleanUp(func() error {
 		return client.RbacV1().ClusterRoleBindings().Delete(context.TODO(), crb.Name, metav1.DeleteOptions{})
 	})
 
@@ -141,7 +141,7 @@ func createDeployment(client kubernetes.Interface, ctx *ScenarioContext, content
 
 	_, err := client.AppsV1().Deployments(d.Namespace).Create(context.TODO(), &d, metav1.CreateOptions{})
 
-	ctx.AddFinalizer(func() error {
+	ctx.AddCleanUp(func() error {
 		dep, err := client.AppsV1().Deployments(d.Namespace).Get(context.TODO(), d.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -202,7 +202,7 @@ func createService(client kubernetes.Interface, ctx *ScenarioContext, content []
 
 	_, err := client.CoreV1().Services(s.Namespace).Create(context.TODO(), s, metav1.CreateOptions{})
 
-	ctx.AddFinalizer(func() error {
+	ctx.AddCleanUp(func() error {
 		return client.CoreV1().Services(s.Namespace).Delete(context.TODO(), s.Name, metav1.DeleteOptions{})
 	})
 
@@ -221,7 +221,7 @@ func createServiceAccount(client kubernetes.Interface, ctx *ScenarioContext, con
 
 	_, err := client.CoreV1().ServiceAccounts(sa.Namespace).Create(context.TODO(), sa, metav1.CreateOptions{})
 
-	ctx.AddFinalizer(func() error {
+	ctx.AddCleanUp(func() error {
 		return client.CoreV1().ServiceAccounts(sa.Namespace).Delete(context.TODO(), sa.Name, metav1.DeleteOptions{})
 	})
 
@@ -240,7 +240,7 @@ func createSecret(client kubernetes.Interface, ctx *ScenarioContext, content []b
 
 	_, err := client.CoreV1().Secrets(secret.Namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
 
-	ctx.AddFinalizer(func() error {
+	ctx.AddCleanUp(func() error {
 		return client.CoreV1().Secrets(secret.Namespace).Delete(context.TODO(), secret.Name, metav1.DeleteOptions{})
 	})
 
@@ -259,7 +259,7 @@ func createConfigmap(client kubernetes.Interface, ctx *ScenarioContext, content 
 
 	_, err := client.CoreV1().ConfigMaps(configmap.Namespace).Create(context.TODO(), configmap, metav1.CreateOptions{})
 
-	ctx.AddFinalizer(func() error {
+	ctx.AddCleanUp(func() error {
 		return client.CoreV1().ConfigMaps(configmap.Namespace).Delete(context.TODO(), configmap.Name, metav1.DeleteOptions{})
 	})
 
@@ -482,7 +482,7 @@ func run(client kubernetes.Interface, ctx *ScenarioContext, image string, name s
 		return fmt.Errorf("failed to create job: %v", err)
 	}
 
-	ctx.AddFinalizer(func() error {
+	ctx.AddCleanUp(func() error {
 		err := client.BatchV1().Jobs(ctx.Namespace).Delete(context.TODO(), batch.Name, metav1.DeleteOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to delete job: %v", err)

--- a/test/kubetest/kubernetes.go
+++ b/test/kubetest/kubernetes.go
@@ -184,7 +184,7 @@ func dumpLogs(client kubernetes.Interface, ctx *ScenarioContext, opts metav1.Lis
 				return
 			}
 
-			io.Copy(os.Stdout, stream)
+			_, _ = io.Copy(os.Stdout, stream)
 		}
 	}
 }

--- a/test/kubetest/kubetest.go
+++ b/test/kubetest/kubetest.go
@@ -45,18 +45,9 @@ type Scenario struct {
 	Name        string
 	Description string
 
-	Given Setup
-	When  Condition
-	Then  Check
-}
-
-type ScenarioContext struct {
-	Namespace string
-	CleanUp   []CleanUp
-}
-
-func (ctx *ScenarioContext) AddCleanUp(f CleanUp) {
-	ctx.CleanUp = append(ctx.CleanUp, f)
+	Given Action
+	When  Action
+	Then  Action
 }
 
 func (s Scenario) Run(t *testing.T) bool {
@@ -93,9 +84,20 @@ func (s Scenario) Run(t *testing.T) bool {
 	})
 }
 
-type Setup func(ctx *ScenarioContext) error
+type ScenarioContext struct {
+	Namespace string
+	CleanUp   []CleanUp
+}
 
-func Setups(ss ...Setup) Setup {
+func (ctx *ScenarioContext) AddCleanUp(f CleanUp) {
+	ctx.CleanUp = append(ctx.CleanUp, f)
+}
+
+type CleanUp func() error
+
+type Action func(ctx *ScenarioContext) error
+
+func Actions(ss ...Action) Action {
 	return func(ctx *ScenarioContext) error {
 		for _, s := range ss {
 			if err := s(ctx); err != nil {
@@ -105,31 +107,3 @@ func Setups(ss ...Setup) Setup {
 		return nil
 	}
 }
-
-type Condition func(ctx *ScenarioContext) error
-
-func Conditions(cs ...Condition) Condition {
-	return func(ctx *ScenarioContext) error {
-		for _, c := range cs {
-			if err := c(ctx); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-}
-
-type Check func(ctx *ScenarioContext) error
-
-func Checks(cs ...Check) Check {
-	return func(ctx *ScenarioContext) error {
-		for _, c := range cs {
-			if err := c(ctx); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-}
-
-type CleanUp func() error

--- a/test/kubetest/kubetest.go
+++ b/test/kubetest/kubetest.go
@@ -76,7 +76,7 @@ func (s Scenario) Run(t *testing.T) bool {
 			}
 		}
 
-		if s.Given != nil {
+		if s.Then != nil {
 			if err := s.Then(ctx); err != nil {
 				t.Errorf("checks failed: %v", err)
 			}

--- a/test/kubetest/kubetest.go
+++ b/test/kubetest/kubetest.go
@@ -25,11 +25,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-type Suite struct {
-	KubeClient kubernetes.Interface
-}
-
-func NewSuiteFromKubeconfig(path string) (*Suite, error) {
+func NewClientFromKubeconfig(path string) (kubernetes.Interface, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", path)
 	if err != nil {
 		return nil, err
@@ -40,7 +36,7 @@ func NewSuiteFromKubeconfig(path string) (*Suite, error) {
 		return nil, err
 	}
 
-	return &Suite{KubeClient: client}, nil
+	return client, nil
 }
 
 type TestSuite func(t *testing.T)

--- a/test/kubetest/kubetest.go
+++ b/test/kubetest/kubetest.go
@@ -57,7 +57,7 @@ type ScenarioContext struct {
 	Finalizer []Finalizer
 }
 
-func (ctx *ScenarioContext) AddFinalizer(f Finalizer) {
+func (ctx *ScenarioContext) AddCleanUp(f Finalizer) {
 	ctx.Finalizer = append(ctx.Finalizer, f)
 }
 
@@ -67,7 +67,7 @@ func RandomNamespace(client kubernetes.Interface) RunOpts {
 	return func(ctx *ScenarioContext) *ScenarioContext {
 		ctx.Namespace = rand.String(8)
 
-		ctx.AddFinalizer(func() error {
+		ctx.AddCleanUp(func() error {
 			return DeleteNamespace(client, ctx.Namespace)
 		})
 


### PR DESCRIPTION
## What

- Reduce abstractions
- Remove unused code
- Fix minor issues
- Rename into less abstract names

## Why

There are so many abstractions, that it takes quite a while to understand the tests:
- Remove suite, use client directly.

Fix:
- Wrong nil check is done in Run function.
- Unnecessary usage of `[]Check`, `[]Setup` in tests.

There is unused code that doesn't work:
- Create random Namespace is never used and doesn't work, without breaking the tests.
- Timeout is not implemented.

Rename:
- It is hard to understand what a Finalizer does, a CleanUp is more common
- Setup, Condition and Check do the exact same thing. There is no need for code duplication.