### PR TITLE
[wip] go.mod,.github: go, kind version bump

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,8 @@ on: [push, pull_request]
 
 env:
   QUAY_PATH: quay.io/brancz/kube-rbac-proxy
-  go-version: '1.17.9'
-  kind-version: 'v0.11.0'
+  go-version: '1.18.3'
+  kind-version: 'v0.14.0'
 
 jobs:
   check-license:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brancz/kube-rbac-proxy
 
-go 1.17
+go 1.18
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
## What

Version bump Go and Kind.

## Why

The current Go version used for building kube-rbac-proxy has some CVEs.

Signed-off-by: Krzysztof Ostrowski <kostrows@redhat.com>