### PR TITLE
Build kube-rbac-proxy binary during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,17 @@
 ARG GOARCH=amd64
+ARG GOOS=linux
+FROM golang:1.18-alpine as builder
+
+WORKDIR /go/src/kube-rbac-proxy
+
+COPY . .
+RUN apk update && apk add --no-cache make && make build
+
 FROM gcr.io/distroless/static:nonroot-$GOARCH
 
-ARG BINARY=kube-rbac-proxy-linux-amd64
-COPY _output/$BINARY /usr/local/bin/kube-rbac-proxy
+ARG GOARCH=amd64
+ARG GOOS=linux
+COPY --from=builder /go/src/kube-rbac-proxy/_output/kube-rbac-proxy /usr/local/bin/kube-rbac-proxy
 EXPOSE 8080
 USER 65532:65532
 

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ update-go-deps:
 	done
 	go mod tidy
 
-container: $(OUT_DIR)/$(BIN)-$(GOOS)-$(GOARCH) Dockerfile
-	docker build --build-arg BINARY=$(BIN)-$(GOOS)-$(GOARCH) --build-arg GOARCH=$(GOARCH) -t $(CONTAINER_NAME)-$(GOARCH) .
+container: Dockerfile
+	docker build --build-arg GOOS=$(GOOS) --build-arg GOARCH=$(GOARCH) -t $(CONTAINER_NAME)-$(GOOS)-$(GOARCH) .
 ifeq ($(GOARCH), amd64)
 	docker tag $(DOCKER_REPO):$(VERSION)-$(GOARCH) $(CONTAINER_NAME)
 endif


### PR DESCRIPTION
This commit removes requirement of compiled binary being present in `_output` directory before calling `make container`. Effectively, `make build` step is no longer dependency of `make container` and `make container` can be executed at the same time for multiple platforms.