### PR TITLE
remove insecure listen address

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Usage of _output/kube-rbac-proxy:
       --client-ca-file string                       If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.
       --config-file string                          Configuration file to configure kube-rbac-proxy.
       --ignore-paths strings                        Comma-separated list of paths against which kube-rbac-proxy pattern-matches the incoming request. If the requst matches, it will proxy the request without performing an authentication or authorization check. Cannot be used with --allow-paths.
-      --insecure-listen-address string              The address the kube-rbac-proxy HTTP server should listen on.
       --kubeconfig string                           Path to a kubeconfig file, specifying how to connect to the API server. If unset, in-cluster configuration will be used
       --log_backtrace_at traceLocation              when logging hits line file:N, emit a stack trace (default :0)
       --log_dir string                              If non-empty, write log files in this directory (no effect when -logtostderr=true)


### PR DESCRIPTION
Offering authn / authz to an insecure server is risky.

The benefits vs risks are easier debugging vs potential for an insecure auth-handling-proxy. The risk outweigh the benefits.

[Ref Issue](https://github.com/brancz/kube-rbac-proxy/issues/169)

Signed-off-by: Krzysztof Ostrowski <kostrows@redhat.com>