### PR TITLE
main.go: add warn logs when insecure opts in use

### DIFF
--- a/main.go
+++ b/main.go
@@ -146,6 +146,25 @@ func main() {
 		klog.Fatalf("Failed to parse upstream URL: %v", err)
 	}
 
+	hasCerts := !(cfg.tls.certFile == "") && !(cfg.tls.keyFile == "")
+	hasInsecureListenAddress := cfg.insecureListenAddress != ""
+	if !hasCerts || hasInsecureListenAddress {
+		klog.Warning(`
+==== Deprecation Warning ======================
+
+We will remove insecure listen address.
+Using --insecure-listen-address will be forbidden!
+
+We will remove the ability to run kube-rbac-proxy without TLS certificates.
+Not using --tls-cert-file and --tls-private-key-file won't work any more!
+
+For more information, please go to https://github.com/brancz/kube-rbac-proxy/issues/187
+
+===============================================
+
+		`)
+	}
+
 	if configFileName != "" {
 		klog.Infof("Reading config file: %s", configFileName)
 		b, err := ioutil.ReadFile(configFileName)

--- a/main.go
+++ b/main.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"flag"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -167,7 +166,7 @@ For more information, please go to https://github.com/brancz/kube-rbac-proxy/iss
 
 	if configFileName != "" {
 		klog.Infof("Reading config file: %s", configFileName)
-		b, err := ioutil.ReadFile(configFileName)
+		b, err := os.ReadFile(configFileName)
 		if err != nil {
 			klog.Fatalf("Failed to read resource-attribute file: %v", err)
 		}

--- a/main.go
+++ b/main.go
@@ -152,10 +152,10 @@ func main() {
 		klog.Warning(`
 ==== Deprecation Warning ======================
 
-We will remove insecure listen address.
-Using --insecure-listen-address will be forbidden!
+Insecure listen address will be removed.
+Using --insecure-listen-address won't be possible!
 
-We will remove the ability to run kube-rbac-proxy without TLS certificates.
+The ability to run kube-rbac-proxy without TLS certificates will be removed.
 Not using --tls-cert-file and --tls-private-key-file won't work any more!
 
 For more information, please go to https://github.com/brancz/kube-rbac-proxy/issues/187

--- a/main.go
+++ b/main.go
@@ -156,7 +156,7 @@ Insecure listen address will be removed.
 Using --insecure-listen-address won't be possible!
 
 The ability to run kube-rbac-proxy without TLS certificates will be removed.
-Not using --tls-cert-file and --tls-private-key-file won't work any more!
+Not using --tls-cert-file and --tls-private-key-file won't be possible!
 
 For more information, please go to https://github.com/brancz/kube-rbac-proxy/issues/187
 

--- a/pkg/tls/reloader.go
+++ b/pkg/tls/reloader.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sync"
 	"time"
 
@@ -44,6 +44,7 @@ type CertReloader struct {
 	certRaw, keyRaw []byte
 }
 
+// NewCertReloader creates a new CertReloader that loads certs in an interval.
 func NewCertReloader(certPath, keyPath string, interval time.Duration) (*CertReloader, error) {
 	r := &CertReloader{
 		certPath: certPath,
@@ -77,12 +78,12 @@ func (r *CertReloader) Watch(ctx context.Context) error {
 }
 
 func (r *CertReloader) reload() error {
-	certRaw, err := ioutil.ReadFile(r.certPath)
+	certRaw, err := os.ReadFile(r.certPath)
 	if err != nil {
 		return fmt.Errorf("error loading certificate: %v", err)
 	}
 
-	keyRaw, err := ioutil.ReadFile(r.keyPath)
+	keyRaw, err := os.ReadFile(r.keyPath)
 	if err != nil {
 		return fmt.Errorf("error loading key: %v", err)
 	}

--- a/pkg/tls/reloader_test.go
+++ b/pkg/tls/reloader_test.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -212,7 +211,7 @@ func newSelfSignedCert(hostname string) stepFunc {
 }
 
 func doubleSymlinkCert(t *testing.T, s *scenario) {
-	name, err := ioutil.TempDir("", "keys")
+	name, err := os.MkdirTemp("", "keys")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,7 +265,7 @@ func swapCert(t *testing.T, s *scenario) {
 }
 
 func swapSymlink(t *testing.T, s *scenario) {
-	name, err := ioutil.TempDir("", "keys")
+	name, err := os.MkdirTemp("", "keys")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -311,7 +310,7 @@ func steps(gs ...stepFunc) stepFunc {
 }
 
 func writeTempFile(pattern string, data []byte) (string, error) {
-	f, err := ioutil.TempFile("", pattern)
+	f, err := os.CreateTemp("", pattern)
 	if err != nil {
 		return "", fmt.Errorf("error creating temp file: %v", err)
 	}

--- a/test/kubetest/kubernetes.go
+++ b/test/kubetest/kubernetes.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -40,7 +39,7 @@ import (
 func CreatedManifests(client kubernetes.Interface, paths ...string) Action {
 	return func(ctx *ScenarioContext) error {
 		for _, path := range paths {
-			content, err := ioutil.ReadFile(path)
+			content, err := os.ReadFile(path)
 			if err != nil {
 				return err
 			}

--- a/transport.go
+++ b/transport.go
@@ -21,9 +21,9 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"time"
 )
 
@@ -32,7 +32,7 @@ func initTransport(upstreamCAFile string) (http.RoundTripper, error) {
 		return http.DefaultTransport, nil
 	}
 
-	rootPEM, err := ioutil.ReadFile(upstreamCAFile)
+	rootPEM, err := os.ReadFile(upstreamCAFile)
 	if err != nil {
 		return nil, fmt.Errorf("error reading upstream CA file: %v", err)
 	}


### PR DESCRIPTION
Warnings for insecure use of kube-rbac-proxy.

# Ref

- [Issue](https://github.com/brancz/kube-rbac-proxy/issues/187)
- [Implementation](https://github.com/brancz/kube-rbac-proxy/pull/186)

Signed-off-by: Krzysztof Ostrowski <kostrows@redhat.com>