### PR TITLE
pkg/proxy: rm unused args

### DIFF
--- a/main.go
+++ b/main.go
@@ -230,11 +230,7 @@ For more information, please go to https://github.com/brancz/kube-rbac-proxy/iss
 		sarAuthorizer,
 	)
 
-	auth, err := proxy.New(kubeClient, cfg.auth, authorizer, authenticator)
-
-	if err != nil {
-		klog.Fatalf("Failed to create rbac-proxy: %v", err)
-	}
+	auth := proxy.New(cfg.auth, authorizer, authenticator)
 
 	upstreamTransport, err := initTransport(cfg.upstreamCAFile)
 	if err != nil {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
-	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 )
 
@@ -55,8 +54,8 @@ func new(authenticator authenticator.Request, authorizer authorizer.Authorizer, 
 }
 
 // New creates an authenticator, an authorizer, and a matching authorizer attributes getter compatible with the kube-rbac-proxy
-func New(client clientset.Interface, config Config, authorizer authorizer.Authorizer, authenticator authenticator.Request) (*kubeRBACProxy, error) {
-	return new(authenticator, authorizer, config), nil
+func New(config Config, authorizer authorizer.Authorizer, authenticator authenticator.Request) *kubeRBACProxy {
+	return new(authenticator, authorizer, config)
 }
 
 // Handle authenticates the client and authorizes the request.

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -30,11 +30,9 @@ import (
 	"k8s.io/apiserver/pkg/authentication/request/bearertoken"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
-	testclient "k8s.io/client-go/kubernetes/fake"
 )
 
 func TestProxyWithOIDCSupport(t *testing.T) {
-	kc := testclient.NewSimpleClientset()
 	cfg := Config{
 		Authentication: &authn.AuthnConfig{
 			OIDC: &authn.OIDCConfig{},
@@ -57,11 +55,7 @@ func TestProxyWithOIDCSupport(t *testing.T) {
 		t.Run(v.description, func(t *testing.T) {
 
 			w := httptest.NewRecorder()
-			proxy, err := New(kc, cfg, v.authorizer, authenticator)
-
-			if err != nil {
-				t.Fatalf("Failed to instantiate test proxy. Details : %s", err.Error())
-			}
+			proxy := New(cfg, v.authorizer, authenticator)
 			proxy.Handle(w, v.req)
 
 			resp := w.Result()


### PR DESCRIPTION
# What

Remove unused args.

# Why

Creates noise and unnecessary imports.

# Ref

- [deads' comment](https://github.com/brancz/kube-rbac-proxy/pull/162#discussion_r834559249)

Signed-off-by: Krzysztof Ostrowski <kostrows@redhat.com>