### PR TITLE
pkg/authz: rename Equal to Matches

### DIFF
--- a/pkg/authz/auth.go
+++ b/pkg/authz/auth.go
@@ -102,7 +102,7 @@ type staticAuthorizer struct {
 	config []StaticAuthorizationConfig
 }
 
-func (saConfig StaticAuthorizationConfig) Equal(a authorizer.Attributes) bool {
+func (saConfig StaticAuthorizationConfig) Matches(a authorizer.Attributes) bool {
 	isAllowed := func(staticConf string, requestVal string) bool {
 		if staticConf == "" {
 			return true
@@ -133,7 +133,7 @@ func (saConfig StaticAuthorizationConfig) Equal(a authorizer.Attributes) bool {
 func (sa staticAuthorizer) Authorize(ctx context.Context, a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
 	// compare a against the configured static auths
 	for _, saConfig := range sa.config {
-		if saConfig.Equal(a) {
+		if saConfig.Matches(a) {
 			return authorizer.DecisionAllow, "found corresponding static auth config", nil
 		}
 	}


### PR DESCRIPTION
# What

Improve Naming.

# Why

Better understanding of what the code does.

# Ref

https://github.com/brancz/kube-rbac-proxy/pull/162#discussion_r834551921

Signed-off-by: Krzysztof Ostrowski <kostrows@redhat.com>