### PR TITLE
[wip] Handler rework

### DIFF
--- a/main.go
+++ b/main.go
@@ -286,12 +286,16 @@ For more information, please go to https://github.com/brancz/kube-rbac-proxy/iss
 	}
 
 	mux := http.NewServeMux()
+	// TODO: create k8s typical handler = middleware1(handler, cfg) logic
 	mux.Handle("/", server.WithAllowPaths(
 		server.WithIgnorePaths(
 			proxy,
 			server.WithAuthentication(
 				server.WithAuthorization(
-					server.WithAuthHeaders(proxy, cfg.auth.Authentication.Header),
+					server.WithAuthHeaders(
+						proxy,
+						cfg.auth.Authentication.Header,
+					),
 					authorizer,
 					cfg.auth.Authorization,
 				),

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package proxy
+package server
 
 import (
 	"bytes"

--- a/pkg/server/handler_test.go
+++ b/pkg/server/handler_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package proxy
+package server
 
 import (
 	"context"


### PR DESCRIPTION
# What

Streamline middleware logic.
Prepare it to become more like k8s/filters.
Prepare it to test it (living outside of `func main`).

# Why

It is pretty messy and easy to break and not  tested well enough.

# TODOs

- [ ] Add unit tests for every middleware.
- [ ] Replace authentication with `filter.WithAuthentication`. 
- [ ] Move server logic into server pkg.
- [ ] Move middleware logic into filters file.
- [ ] Make gap between k8s-style-logic and krp smaller.

# Ref

## Fixes

https://github.com/brancz/kube-rbac-proxy/pull/162#discussion_r834559249
https://github.com/brancz/kube-rbac-proxy/pull/162#discussion_r834560795
https://github.com/brancz/kube-rbac-proxy/pull/162#discussion_r840647634
https://github.com/brancz/kube-rbac-proxy/pull/162#discussion_r840650815
https://github.com/brancz/kube-rbac-proxy/pull/162#discussion_r840652866
https://github.com/brancz/kube-rbac-proxy/pull/162#discussion_r840654580

## Prepares

https://github.com/brancz/kube-rbac-proxy/pull/162#discussion_r834563855
https://github.com/brancz/kube-rbac-proxy/pull/162#discussion_r834565383
https://github.com/brancz/kube-rbac-proxy/pull/162#discussion_r834570446
https://github.com/brancz/kube-rbac-proxy/pull/162#discussion_r840651647