### PR TITLE
Allow path as filter

### DIFF
--- a/main.go
+++ b/main.go
@@ -287,8 +287,7 @@ For more information, please go to https://github.com/brancz/kube-rbac-proxy/iss
 		}
 	}
 
-	mux := http.NewServeMux()
-	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		found := len(cfg.allowPaths) == 0
 		for _, pathAllowed := range cfg.allowPaths {
 			found, err = path.Match(pathAllowed, req.URL.Path)
@@ -333,7 +332,10 @@ For more information, please go to https://github.com/brancz/kube-rbac-proxy/iss
 		}
 
 		proxy.ServeHTTP(w, req)
-	}))
+	})
+
+	mux := http.NewServeMux()
+	mux.Handle("/", handler)
 
 	var gr run.Group
 	{

--- a/pkg/filters/path.go
+++ b/pkg/filters/path.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2022 the kube-rbac-proxy maintainers All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package filters
 
 import (

--- a/pkg/filters/path.go
+++ b/pkg/filters/path.go
@@ -1,0 +1,33 @@
+package filters
+
+import (
+	"net/http"
+	"path"
+)
+
+func WithAllowPaths(allowPaths []string, handler http.HandlerFunc) http.HandlerFunc {
+	if len(allowPaths) == 0 {
+		return handler
+	}
+
+	return func(w http.ResponseWriter, req *http.Request) {
+		for _, pathAllowed := range allowPaths {
+			found, err := path.Match(pathAllowed, req.URL.Path)
+			if err != nil {
+				http.Error(
+					w,
+					http.StatusText(http.StatusInternalServerError),
+					http.StatusInternalServerError,
+				)
+				return
+			}
+
+			if found {
+				handler.ServeHTTP(w, req)
+				return
+			}
+		}
+
+		http.NotFound(w, req)
+	}
+}

--- a/pkg/filters/path_test.go
+++ b/pkg/filters/path_test.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2022 the kube-rbac-proxy maintainers All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package filters_test
 
 import (

--- a/pkg/filters/path_test.go
+++ b/pkg/filters/path_test.go
@@ -1,0 +1,58 @@
+package filters_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/brancz/kube-rbac-proxy/pkg/filters"
+)
+
+func emptyHandler(w http.ResponseWriter, r *http.Request) {}
+
+func TestAllowPath(t *testing.T) {
+	validPath := "/allowed"
+
+	for _, tt := range []struct {
+		name   string
+		paths  []string
+		status int
+	}{
+		{
+			name:   "should let request through if path allowed",
+			paths:  []string{validPath},
+			status: http.StatusOK,
+		},
+		{
+			name:   "should not let request through if path not allowed",
+			paths:  []string{"/denied"},
+			status: http.StatusNotFound,
+		},
+		{
+			name:   "should let request through if no path specified",
+			paths:  []string{},
+			status: http.StatusOK,
+		},
+		{
+			name:   "should not let request through if path is non-sense",
+			paths:  []string{"[]a]"},
+			status: http.StatusInternalServerError,
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, validPath, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			filters.WithAllowPaths(tt.paths, emptyHandler).ServeHTTP(rec, req)
+			res := rec.Result()
+
+			if res.StatusCode != tt.status {
+				t.Errorf("want: %d\nhave: %d\n", tt.status, res.StatusCode)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Move allow path logic into a filter.

## Why

This is part of a bigger refactoring around the filters for the proxy.
It should make the code easier to read and unit-tested.