### PR TITLE
Auth as filter

### DIFF
--- a/pkg/filters/auth.go
+++ b/pkg/filters/auth.go
@@ -1,14 +1,25 @@
 package filters
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
+
+	"github.com/brancz/kube-rbac-proxy/pkg/authn"
+	"github.com/brancz/kube-rbac-proxy/pkg/authz"
+	"github.com/brancz/kube-rbac-proxy/pkg/proxy"
 
 	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/klog/v2"
 )
 
-func WithAuthentication(authReq authenticator.Request, audiences []string, handler http.HandlerFunc) http.HandlerFunc {
+func WithAuthentication(
+	authReq authenticator.Request,
+	audiences []string,
+	handler http.HandlerFunc,
+) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		if len(audiences) > 0 {
@@ -28,6 +39,72 @@ func WithAuthentication(authReq authenticator.Request, audiences []string, handl
 		}
 
 		req = req.WithContext(request.WithUser(req.Context(), res.User))
+		handler.ServeHTTP(w, req)
+	}
+}
+
+func WithAuthorization(
+	authz authorizer.Authorizer,
+	cfg *authz.Config,
+	handler http.HandlerFunc,
+) http.HandlerFunc {
+	getRequestAttributes := proxy.
+		NewKubeRBACProxyAuthorizerAttributesGetter(cfg).
+		GetRequestAttributes
+
+	return func(w http.ResponseWriter, req *http.Request) {
+		u, ok := request.UserFrom(req.Context())
+		if !ok {
+			http.Error(w, "user not in context", http.StatusBadRequest)
+			return
+		}
+
+		// Get authorization attributes
+		allAttrs := getRequestAttributes(u, req)
+		if len(allAttrs) == 0 {
+			msg := "Bad Request. The request or configuration is malformed."
+			klog.V(2).Info(msg)
+			http.Error(w, msg, http.StatusBadRequest)
+			return
+		}
+
+		for _, attrs := range allAttrs {
+			// Authorize
+			authorized, reason, err := authz.Authorize(req.Context(), attrs)
+			if err != nil {
+				msg := fmt.Sprintf("Authorization error (user=%s, verb=%s, resource=%s, subresource=%s)", u.GetName(), attrs.GetVerb(), attrs.GetResource(), attrs.GetSubresource())
+				klog.Errorf("%s: %s", msg, err)
+				http.Error(w, msg, http.StatusInternalServerError)
+				return
+			}
+			if authorized != authorizer.DecisionAllow {
+				msg := fmt.Sprintf("Forbidden (user=%s, verb=%s, resource=%s, subresource=%s)", u.GetName(), attrs.GetVerb(), attrs.GetResource(), attrs.GetSubresource())
+				klog.V(2).Infof("%s. Reason: %q.", msg, reason)
+				http.Error(w, msg, http.StatusForbidden)
+				return
+			}
+		}
+
+		handler.ServeHTTP(w, req)
+	}
+}
+
+// WithAuthHeaders adds identity information to the headers.
+// Must not be used, if connection is not encrypted with TLS.
+func WithAuthHeaders(cfg *authn.AuthnHeaderConfig, handler http.HandlerFunc) http.HandlerFunc {
+	if !cfg.Enabled {
+		return handler
+	}
+
+	return func(w http.ResponseWriter, req *http.Request) {
+		u, ok := request.UserFrom(req.Context())
+		if ok {
+			// Seemingly well-known headers to tell the upstream about user's identity
+			// so that the upstream can achieve the original goal of delegating RBAC authn/authz to kube-rbac-proxy
+			req.Header.Set(cfg.UserFieldName, u.GetName())
+			req.Header.Set(cfg.GroupsFieldName, strings.Join(u.GetGroups(), cfg.GroupSeparator))
+		}
+
 		handler.ServeHTTP(w, req)
 	}
 }

--- a/pkg/filters/auth.go
+++ b/pkg/filters/auth.go
@@ -1,0 +1,33 @@
+package filters
+
+import (
+	"net/http"
+
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/klog/v2"
+)
+
+func WithAuthentication(authReq authenticator.Request, audiences []string, handler http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
+		if len(audiences) > 0 {
+			ctx = authenticator.WithAudiences(ctx, audiences)
+			req = req.WithContext(ctx)
+		}
+
+		res, ok, err := authReq.AuthenticateRequest(req)
+		if err != nil {
+			klog.Errorf("Unable to authenticate the request due to an error: %v", err)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		if !ok {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		req = req.WithContext(request.WithUser(req.Context(), res.User))
+		handler.ServeHTTP(w, req)
+	}
+}

--- a/pkg/filters/auth_test.go
+++ b/pkg/filters/auth_test.go
@@ -1,0 +1,151 @@
+package filters_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/brancz/kube-rbac-proxy/pkg/authn"
+	"github.com/brancz/kube-rbac-proxy/pkg/authz"
+	"github.com/brancz/kube-rbac-proxy/pkg/filters"
+	"github.com/brancz/kube-rbac-proxy/pkg/proxy"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/request/bearertoken"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+func TestProxyWithOIDCSupport(t *testing.T) {
+	cfg := proxy.Config{
+		Authentication: &authn.AuthnConfig{
+			OIDC: &authn.OIDCConfig{},
+			Header: &authn.AuthnHeaderConfig{
+				Enabled:         true,
+				UserFieldName:   "user",
+				GroupsFieldName: "groups",
+			},
+			Token: &authn.TokenConfig{},
+		},
+		Authorization: &authz.Config{},
+	}
+
+	fakeUser := user.DefaultInfo{Name: "Foo Bar", Groups: []string{"foo-bars"}}
+	authenticator := fakeOIDCAuthenticator(t, &fakeUser)
+
+	scenario := setupTestScenario()
+	for _, v := range scenario {
+
+		t.Run(v.description, func(t *testing.T) {
+			w := httptest.NewRecorder()
+
+			filters.WithAuthentication(
+				authenticator, cfg.Authentication.Token.Audiences,
+				func(w http.ResponseWriter, req *http.Request) {
+					proxy.New(cfg, v.authorizer).Handle(w, req)
+				},
+			)(w, v.req)
+
+			resp := w.Result()
+
+			if resp.StatusCode != v.status {
+				t.Errorf("Expected response: %d received : %d", v.status, resp.StatusCode)
+			}
+
+			if v.verifyUser {
+				user := v.req.Header.Get(cfg.Authentication.Header.UserFieldName)
+				groups := v.req.Header.Get(cfg.Authentication.Header.GroupsFieldName)
+				if user != fakeUser.GetName() {
+					t.Errorf("User in the response header does not match authenticated user. Expected : %s, received : %s ", fakeUser.GetName(), user)
+				}
+				if groups != strings.Join(fakeUser.GetGroups(), cfg.Authentication.Header.GroupSeparator) {
+					t.Errorf("Groupsr in the response header does not match authenticated user groups. Expected : %s, received : %s ", fakeUser.GetName(), groups)
+				}
+			}
+		})
+	}
+}
+
+func setupTestScenario() []testCase {
+	testScenario := []testCase{
+		{
+			description: "Request with invalid Token should be authenticated and rejected with 401",
+			given: given{
+				req:        fakeJWTRequest("GET", "/accounts", "Bearer INVALID"),
+				authorizer: denier{},
+			},
+			expected: expected{
+				status: http.StatusUnauthorized,
+			},
+		},
+		{
+			description: "Request with valid token should return 403 due to lack of permissions",
+			given: given{
+				req:        fakeJWTRequest("GET", "/accounts", "Bearer VALID"),
+				authorizer: denier{},
+			},
+			expected: expected{
+				status: http.StatusForbidden,
+			},
+		},
+		{
+			description: "Request with valid token, should return 200 due to lack of permissions",
+			given: given{
+				req:        fakeJWTRequest("GET", "/accounts", "Bearer VALID"),
+				authorizer: approver{},
+			},
+			expected: expected{
+				status:     http.StatusOK,
+				verifyUser: true,
+			},
+		},
+	}
+	return testScenario
+}
+
+func fakeJWTRequest(method, path, token string) *http.Request {
+	req := httptest.NewRequest(method, path, nil)
+	req.Header.Add("Authorization", token)
+
+	return req
+}
+
+func fakeOIDCAuthenticator(t *testing.T, fakeUser *user.DefaultInfo) authenticator.Request {
+
+	auth := bearertoken.New(authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
+		if token != "VALID" {
+			return nil, false, nil
+		}
+		return &authenticator.Response{User: fakeUser}, true, nil
+	}))
+	return auth
+}
+
+type denier struct{}
+
+func (d denier) Authorize(ctx context.Context, auth authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
+	return authorizer.DecisionDeny, "user not allowed", nil
+}
+
+type approver struct{}
+
+func (a approver) Authorize(ctx context.Context, auth authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
+	return authorizer.DecisionAllow, "user allowed", nil
+}
+
+type given struct {
+	req        *http.Request
+	authorizer authorizer.Authorizer
+}
+
+type expected struct {
+	status     int
+	verifyUser bool
+}
+
+type testCase struct {
+	given
+	expected
+	description string
+}

--- a/pkg/filters/auth_test.go
+++ b/pkg/filters/auth_test.go
@@ -2,6 +2,7 @@ package filters_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -16,7 +17,241 @@ import (
 	"k8s.io/apiserver/pkg/authentication/request/bearertoken"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/endpoints/request"
 )
+
+func TestWithAuthentication(t *testing.T) {
+	audience := []string{"apiserver"}
+
+	for _, tt := range []struct {
+		name          string
+		authenticator authenticator.Request
+		audiences     []string
+		status        int
+	}{
+		{
+			name: "should return 200 ok on successful authn",
+			authenticator: authenticatorFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+				return &authenticator.Response{
+					Audiences: []string{},
+					User: &user.DefaultInfo{
+						Name:   "Ben Utzer",
+						UID:    "1337",
+						Groups: []string{},
+						Extra:  map[string][]string{},
+					},
+				}, true, nil
+			}),
+			status: http.StatusOK,
+		},
+		{
+			name: "should put audiences into the ctx",
+			authenticator: authenticatorFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+				aud, ok := authenticator.AudiencesFrom(req.Context())
+				if !ok {
+					t.Errorf("want: %s\nhave: ok == false", audience)
+				}
+				if aud[0] != audience[0] {
+					t.Errorf("want: %s\nhave: %s", audience, aud)
+				}
+
+				return nil, false, nil
+			}),
+			audiences: audience,
+			status:    http.StatusUnauthorized,
+		},
+		{
+			name: "should return unauthorized on err",
+			authenticator: authenticatorFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+				return nil, false, errors.New("this is an error")
+			}),
+			status: http.StatusUnauthorized,
+		},
+		{
+			name: "should return unauthorized on authentication failure",
+			authenticator: authenticatorFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+				return nil, false, nil
+			}),
+			status: http.StatusUnauthorized,
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rec := httptest.NewRecorder()
+			filters.WithAuthentication(
+				tt.authenticator,
+				tt.audiences,
+				func(w http.ResponseWriter, r *http.Request) {},
+			).ServeHTTP(rec, req)
+
+			res := rec.Result()
+			if res.StatusCode != tt.status {
+				t.Errorf("want: %d\nhave: %d\n", tt.status, res.StatusCode)
+			}
+		})
+	}
+}
+
+type authenticatorFunc func(*http.Request) (*authenticator.Response, bool, error)
+
+func (a authenticatorFunc) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+	return a(req)
+}
+
+func TestWithAuthorization(t *testing.T) {
+	emptyRequest, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	userRequest := emptyRequest.WithContext(
+		request.WithUser(emptyRequest.Context(), &user.DefaultInfo{}),
+	)
+
+	for _, tt := range []struct {
+		name   string
+		req    *http.Request
+		authz  authorizer.Authorizer
+		cfg    *authz.Config
+		status int
+	}{
+		{
+			name:   "should fail without user in context",
+			req:    emptyRequest,
+			authz:  nil,
+			cfg:    &authz.Config{},
+			status: http.StatusBadRequest,
+		},
+		{
+			name:  "should fail without authorization attributes",
+			req:   userRequest,
+			authz: nil,
+			cfg: &authz.Config{
+				ResourceAttributes: &authz.ResourceAttributes{},
+				Rewrites:           &authz.SubjectAccessReviewRewrites{},
+			},
+			status: http.StatusBadRequest,
+		},
+		{
+			name: "should fail with error on authorization",
+			req:  userRequest,
+			authz: authorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+				return authorizer.DecisionDeny, "there is an error", errors.New("this is an error")
+			}),
+			cfg:    &authz.Config{},
+			status: http.StatusInternalServerError,
+		},
+		{
+			name: "should fail with authorization failure",
+			req:  userRequest,
+			authz: authorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+				return authorizer.DecisionDeny, "not authorized", nil
+			}),
+			cfg:    &authz.Config{},
+			status: http.StatusForbidden,
+		},
+		{
+			name: "should succeed with authorization",
+			req:  userRequest,
+			authz: authorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+				return authorizer.DecisionAllow, "authorized!", nil
+			}),
+			cfg:    &authz.Config{},
+			status: http.StatusOK,
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			filters.WithAuthorization(
+				tt.authz,
+				tt.cfg,
+				func(w http.ResponseWriter, r *http.Request) {},
+			).ServeHTTP(rec, tt.req)
+
+			res := rec.Result()
+			if tt.status != res.StatusCode {
+				t.Errorf("want: %d\nhave: %d", tt.status, res.StatusCode)
+			}
+		})
+	}
+}
+
+type authorizerFunc func(context.Context, authorizer.Attributes) (authorizer.Decision, string, error)
+
+func (a authorizerFunc) Authorize(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+	return a(ctx, attr)
+}
+
+func TestWithAuthHeaders(t *testing.T) {
+	okHandler := func(w http.ResponseWriter, r *http.Request) {}
+	userKey := "User"
+	userValue := "ben"
+	groupKey := "Group"
+	groupValue := "utzer"
+
+	for _, tt := range []struct {
+		name   string
+		cfg    *authn.AuthnHeaderConfig
+		ctx    context.Context
+		header map[string][]string
+	}{
+		{
+			name:   "should pass through",
+			cfg:    &authn.AuthnHeaderConfig{Enabled: false},
+			header: map[string][]string{},
+		},
+		{
+			name: "should set username in header",
+			cfg: &authn.AuthnHeaderConfig{
+				Enabled:         true,
+				UserFieldName:   userKey,
+				GroupsFieldName: groupKey,
+			},
+			header: map[string][]string{
+				userKey:  {userValue},
+				groupKey: {groupValue},
+			},
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req = req.WithContext(
+				request.WithUser(
+					req.Context(),
+					&user.DefaultInfo{
+						Name:   userValue,
+						Groups: []string{groupValue},
+					},
+				),
+			)
+
+			rec := httptest.NewRecorder()
+			filters.WithAuthHeaders(tt.cfg, okHandler).ServeHTTP(rec, req)
+
+			if len(req.Header) != len(tt.header) {
+				t.Errorf("want: %+v\nhave:%+v", tt.header, req.Header)
+				return
+			}
+
+			if len(tt.header) > 0 {
+				for k, v := range tt.header {
+					if req.Header[k][0] != v[0] {
+						t.Errorf("want: %s\nhave: %s", v[0], req.Header[k][0])
+					}
+				}
+			}
+		})
+	}
+}
 
 func TestProxyWithOIDCSupport(t *testing.T) {
 	cfg := proxy.Config{
@@ -35,40 +270,7 @@ func TestProxyWithOIDCSupport(t *testing.T) {
 	fakeUser := user.DefaultInfo{Name: "Foo Bar", Groups: []string{"foo-bars"}}
 	authenticator := fakeOIDCAuthenticator(t, &fakeUser)
 
-	scenario := setupTestScenario()
-	for _, v := range scenario {
-
-		t.Run(v.description, func(t *testing.T) {
-			w := httptest.NewRecorder()
-
-			handler := func(w http.ResponseWriter, r *http.Request) {}
-			handler = filters.WithAuthHeaders(cfg.Authentication.Header, handler)
-			handler = filters.WithAuthorization(v.authorizer, cfg.Authorization, handler)
-			handler = filters.WithAuthentication(authenticator, cfg.Authentication.Token.Audiences, handler)
-
-			handler(w, v.req)
-			resp := w.Result()
-
-			if resp.StatusCode != v.status {
-				t.Errorf("Expected response: %d received : %d", v.status, resp.StatusCode)
-			}
-
-			if v.verifyUser {
-				user := v.req.Header.Get(cfg.Authentication.Header.UserFieldName)
-				groups := v.req.Header.Get(cfg.Authentication.Header.GroupsFieldName)
-				if user != fakeUser.GetName() {
-					t.Errorf("User in the response header does not match authenticated user. Expected : %s, received : %s ", fakeUser.GetName(), user)
-				}
-				if groups != strings.Join(fakeUser.GetGroups(), cfg.Authentication.Header.GroupSeparator) {
-					t.Errorf("Groupsr in the response header does not match authenticated user groups. Expected : %s, received : %s ", fakeUser.GetName(), groups)
-				}
-			}
-		})
-	}
-}
-
-func setupTestScenario() []testCase {
-	testScenario := []testCase{
+	for _, v := range []testCase{
 		{
 			description: "Request with invalid Token should be authenticated and rejected with 401",
 			given: given{
@@ -100,8 +302,35 @@ func setupTestScenario() []testCase {
 				verifyUser: true,
 			},
 		},
+	} {
+
+		t.Run(v.description, func(t *testing.T) {
+			w := httptest.NewRecorder()
+
+			handler := func(w http.ResponseWriter, r *http.Request) {}
+			handler = filters.WithAuthHeaders(cfg.Authentication.Header, handler)
+			handler = filters.WithAuthorization(v.authorizer, cfg.Authorization, handler)
+			handler = filters.WithAuthentication(authenticator, cfg.Authentication.Token.Audiences, handler)
+
+			handler(w, v.req)
+			resp := w.Result()
+
+			if resp.StatusCode != v.status {
+				t.Errorf("Expected response: %d received : %d", v.status, resp.StatusCode)
+			}
+
+			if v.verifyUser {
+				user := v.req.Header.Get(cfg.Authentication.Header.UserFieldName)
+				groups := v.req.Header.Get(cfg.Authentication.Header.GroupsFieldName)
+				if user != fakeUser.GetName() {
+					t.Errorf("User in the response header does not match authenticated user. Expected : %s, received : %s ", fakeUser.GetName(), user)
+				}
+				if groups != strings.Join(fakeUser.GetGroups(), cfg.Authentication.Header.GroupSeparator) {
+					t.Errorf("Groupsr in the response header does not match authenticated user groups. Expected : %s, received : %s ", fakeUser.GetName(), groups)
+				}
+			}
+		})
 	}
-	return testScenario
 }
 
 func fakeJWTRequest(method, path, token string) *http.Request {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -18,17 +18,14 @@ package proxy
 
 import (
 	"bytes"
-	"fmt"
 	"net/http"
 	"net/textproto"
-	"strings"
 	"text/template"
 
 	"github.com/brancz/kube-rbac-proxy/pkg/authn"
 	"github.com/brancz/kube-rbac-proxy/pkg/authz"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
-	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/klog/v2"
 )
 
@@ -38,71 +35,7 @@ type Config struct {
 	Authorization  *authz.Config
 }
 
-type kubeRBACProxy struct {
-	// authorizer determines whether a given authorization.Attributes is allowed
-	authorizer.Authorizer
-	// authorizerAttributesGetter implements retrieving authorization attributes for a respective request.
-	authorizerAttributesGetter *krpAuthorizerAttributesGetter
-	// config for kube-rbac-proxy
-	Config Config
-}
-
-func new(authorizer authorizer.Authorizer, config Config) *kubeRBACProxy {
-	return &kubeRBACProxy{authorizer, newKubeRBACProxyAuthorizerAttributesGetter(config.Authorization), config}
-}
-
-// New creates an authenticator, an authorizer, and a matching authorizer attributes getter compatible with the kube-rbac-proxy
-func New(config Config, authorizer authorizer.Authorizer) *kubeRBACProxy {
-	return new(authorizer, config)
-}
-
-// Handle authenticates the client and authorizes the request.
-// If the authn fails, a 401 error is returned. If the authz fails, a 403 error is returned
-func (h *kubeRBACProxy) Handle(w http.ResponseWriter, req *http.Request) bool {
-	u, ok := request.UserFrom(req.Context())
-	if !ok {
-		http.Error(w, "user not in context", http.StatusBadRequest)
-		return false
-	}
-
-	// Get authorization attributes
-	allAttrs := h.authorizerAttributesGetter.GetRequestAttributes(u, req)
-	if len(allAttrs) == 0 {
-		msg := "Bad Request. The request or configuration is malformed."
-		klog.V(2).Info(msg)
-		http.Error(w, msg, http.StatusBadRequest)
-		return false
-	}
-
-	for _, attrs := range allAttrs {
-		// Authorize
-		authorized, reason, err := h.Authorize(req.Context(), attrs)
-		if err != nil {
-			msg := fmt.Sprintf("Authorization error (user=%s, verb=%s, resource=%s, subresource=%s)", u.GetName(), attrs.GetVerb(), attrs.GetResource(), attrs.GetSubresource())
-			klog.Errorf("%s: %s", msg, err)
-			http.Error(w, msg, http.StatusInternalServerError)
-			return false
-		}
-		if authorized != authorizer.DecisionAllow {
-			msg := fmt.Sprintf("Forbidden (user=%s, verb=%s, resource=%s, subresource=%s)", u.GetName(), attrs.GetVerb(), attrs.GetResource(), attrs.GetSubresource())
-			klog.V(2).Infof("%s. Reason: %q.", msg, reason)
-			http.Error(w, msg, http.StatusForbidden)
-			return false
-		}
-	}
-
-	if h.Config.Authentication.Header.Enabled {
-		// Seemingly well-known headers to tell the upstream about user's identity
-		// so that the upstream can achieve the original goal of delegating RBAC authn/authz to kube-rbac-proxy
-		headerCfg := h.Config.Authentication.Header
-		req.Header.Set(headerCfg.UserFieldName, u.GetName())
-		req.Header.Set(headerCfg.GroupsFieldName, strings.Join(u.GetGroups(), headerCfg.GroupSeparator))
-	}
-
-	return true
-}
-
-func newKubeRBACProxyAuthorizerAttributesGetter(authzConfig *authz.Config) *krpAuthorizerAttributesGetter {
+func NewKubeRBACProxyAuthorizerAttributesGetter(authzConfig *authz.Config) *krpAuthorizerAttributesGetter {
 	return &krpAuthorizerAttributesGetter{authzConfig}
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -26,9 +26,9 @@ import (
 
 	"github.com/brancz/kube-rbac-proxy/pkg/authn"
 	"github.com/brancz/kube-rbac-proxy/pkg/authz"
-	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/klog/v2"
 )
 
@@ -39,8 +39,6 @@ type Config struct {
 }
 
 type kubeRBACProxy struct {
-	// authenticator identifies the user for requests to kube-rbac-proxy
-	authenticator.Request
 	// authorizer determines whether a given authorization.Attributes is allowed
 	authorizer.Authorizer
 	// authorizerAttributesGetter implements retrieving authorization attributes for a respective request.
@@ -49,38 +47,26 @@ type kubeRBACProxy struct {
 	Config Config
 }
 
-func new(authenticator authenticator.Request, authorizer authorizer.Authorizer, config Config) *kubeRBACProxy {
-	return &kubeRBACProxy{authenticator, authorizer, newKubeRBACProxyAuthorizerAttributesGetter(config.Authorization), config}
+func new(authorizer authorizer.Authorizer, config Config) *kubeRBACProxy {
+	return &kubeRBACProxy{authorizer, newKubeRBACProxyAuthorizerAttributesGetter(config.Authorization), config}
 }
 
 // New creates an authenticator, an authorizer, and a matching authorizer attributes getter compatible with the kube-rbac-proxy
-func New(config Config, authorizer authorizer.Authorizer, authenticator authenticator.Request) *kubeRBACProxy {
-	return new(authenticator, authorizer, config)
+func New(config Config, authorizer authorizer.Authorizer) *kubeRBACProxy {
+	return new(authorizer, config)
 }
 
 // Handle authenticates the client and authorizes the request.
 // If the authn fails, a 401 error is returned. If the authz fails, a 403 error is returned
 func (h *kubeRBACProxy) Handle(w http.ResponseWriter, req *http.Request) bool {
-	ctx := req.Context()
-	if len(h.Config.Authentication.Token.Audiences) > 0 {
-		ctx = authenticator.WithAudiences(ctx, h.Config.Authentication.Token.Audiences)
-		req = req.WithContext(ctx)
-	}
-
-	// Authenticate
-	u, ok, err := h.AuthenticateRequest(req)
-	if err != nil {
-		klog.Errorf("Unable to authenticate the request due to an error: %v", err)
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
-		return false
-	}
+	u, ok := request.UserFrom(req.Context())
 	if !ok {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		http.Error(w, "user not in context", http.StatusBadRequest)
 		return false
 	}
 
 	// Get authorization attributes
-	allAttrs := h.authorizerAttributesGetter.GetRequestAttributes(u.User, req)
+	allAttrs := h.authorizerAttributesGetter.GetRequestAttributes(u, req)
 	if len(allAttrs) == 0 {
 		msg := "Bad Request. The request or configuration is malformed."
 		klog.V(2).Info(msg)
@@ -90,15 +76,15 @@ func (h *kubeRBACProxy) Handle(w http.ResponseWriter, req *http.Request) bool {
 
 	for _, attrs := range allAttrs {
 		// Authorize
-		authorized, reason, err := h.Authorize(ctx, attrs)
+		authorized, reason, err := h.Authorize(req.Context(), attrs)
 		if err != nil {
-			msg := fmt.Sprintf("Authorization error (user=%s, verb=%s, resource=%s, subresource=%s)", u.User.GetName(), attrs.GetVerb(), attrs.GetResource(), attrs.GetSubresource())
+			msg := fmt.Sprintf("Authorization error (user=%s, verb=%s, resource=%s, subresource=%s)", u.GetName(), attrs.GetVerb(), attrs.GetResource(), attrs.GetSubresource())
 			klog.Errorf("%s: %s", msg, err)
 			http.Error(w, msg, http.StatusInternalServerError)
 			return false
 		}
 		if authorized != authorizer.DecisionAllow {
-			msg := fmt.Sprintf("Forbidden (user=%s, verb=%s, resource=%s, subresource=%s)", u.User.GetName(), attrs.GetVerb(), attrs.GetResource(), attrs.GetSubresource())
+			msg := fmt.Sprintf("Forbidden (user=%s, verb=%s, resource=%s, subresource=%s)", u.GetName(), attrs.GetVerb(), attrs.GetResource(), attrs.GetSubresource())
 			klog.V(2).Infof("%s. Reason: %q.", msg, reason)
 			http.Error(w, msg, http.StatusForbidden)
 			return false
@@ -109,8 +95,8 @@ func (h *kubeRBACProxy) Handle(w http.ResponseWriter, req *http.Request) bool {
 		// Seemingly well-known headers to tell the upstream about user's identity
 		// so that the upstream can achieve the original goal of delegating RBAC authn/authz to kube-rbac-proxy
 		headerCfg := h.Config.Authentication.Header
-		req.Header.Set(headerCfg.UserFieldName, u.User.GetName())
-		req.Header.Set(headerCfg.GroupsFieldName, strings.Join(u.User.GetGroups(), headerCfg.GroupSeparator))
+		req.Header.Set(headerCfg.UserFieldName, u.GetName())
+		req.Header.Set(headerCfg.GroupsFieldName, strings.Join(u.GetGroups(), headerCfg.GroupSeparator))
 	}
 
 	return true

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -17,66 +17,14 @@ limitations under the License.
 package proxy
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
-	"github.com/brancz/kube-rbac-proxy/pkg/authn"
 	"github.com/brancz/kube-rbac-proxy/pkg/authz"
 	"github.com/google/go-cmp/cmp"
-	"k8s.io/apiserver/pkg/authentication/authenticator"
-	"k8s.io/apiserver/pkg/authentication/request/bearertoken"
-	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
-
-func TestProxyWithOIDCSupport(t *testing.T) {
-	cfg := Config{
-		Authentication: &authn.AuthnConfig{
-			OIDC: &authn.OIDCConfig{},
-			Header: &authn.AuthnHeaderConfig{
-				Enabled:         true,
-				UserFieldName:   "user",
-				GroupsFieldName: "groups",
-			},
-			Token: &authn.TokenConfig{},
-		},
-		Authorization: &authz.Config{},
-	}
-
-	fakeUser := user.DefaultInfo{Name: "Foo Bar", Groups: []string{"foo-bars"}}
-	authenticator := fakeOIDCAuthenticator(t, &fakeUser)
-
-	scenario := setupTestScenario()
-	for _, v := range scenario {
-
-		t.Run(v.description, func(t *testing.T) {
-
-			w := httptest.NewRecorder()
-			proxy := New(cfg, v.authorizer, authenticator)
-			proxy.Handle(w, v.req)
-
-			resp := w.Result()
-
-			if resp.StatusCode != v.status {
-				t.Errorf("Expected response: %d received : %d", v.status, resp.StatusCode)
-			}
-
-			if v.verifyUser {
-				user := v.req.Header.Get(cfg.Authentication.Header.UserFieldName)
-				groups := v.req.Header.Get(cfg.Authentication.Header.GroupsFieldName)
-				if user != fakeUser.GetName() {
-					t.Errorf("User in the response header does not match authenticated user. Expected : %s, received : %s ", fakeUser.GetName(), user)
-				}
-				if groups != strings.Join(fakeUser.GetGroups(), cfg.Authentication.Header.GroupSeparator) {
-					t.Errorf("Groupsr in the response header does not match authenticated user groups. Expected : %s, received : %s ", fakeUser.GetName(), groups)
-				}
-			}
-		})
-	}
-}
 
 func TestGeneratingAuthorizerAttributes(t *testing.T) {
 	cases := []struct {
@@ -283,87 +231,4 @@ func createRequest(queryParams, headers map[string][]string) *http.Request {
 		}
 	}
 	return r
-}
-
-func setupTestScenario() []testCase {
-	testScenario := []testCase{
-		{
-			description: "Request with invalid Token should be authenticated and rejected with 401",
-			given: given{
-				req:        fakeJWTRequest("GET", "/accounts", "Bearer INVALID"),
-				authorizer: denier{},
-			},
-			expected: expected{
-				status: http.StatusUnauthorized,
-			},
-		},
-		{
-			description: "Request with valid token should return 403 due to lack of permissions",
-			given: given{
-				req:        fakeJWTRequest("GET", "/accounts", "Bearer VALID"),
-				authorizer: denier{},
-			},
-			expected: expected{
-				status: http.StatusForbidden,
-			},
-		},
-		{
-			description: "Request with valid token, should return 200 due to lack of permissions",
-			given: given{
-				req:        fakeJWTRequest("GET", "/accounts", "Bearer VALID"),
-				authorizer: approver{},
-			},
-			expected: expected{
-				status:     http.StatusOK,
-				verifyUser: true,
-			},
-		},
-	}
-	return testScenario
-}
-
-func fakeJWTRequest(method, path, token string) *http.Request {
-	req := httptest.NewRequest(method, path, nil)
-	req.Header.Add("Authorization", token)
-
-	return req
-}
-
-func fakeOIDCAuthenticator(t *testing.T, fakeUser *user.DefaultInfo) authenticator.Request {
-
-	auth := bearertoken.New(authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
-		if token != "VALID" {
-			return nil, false, nil
-		}
-		return &authenticator.Response{User: fakeUser}, true, nil
-	}))
-	return auth
-}
-
-type denier struct{}
-
-func (d denier) Authorize(ctx context.Context, auth authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
-	return authorizer.DecisionDeny, "user not allowed", nil
-}
-
-type approver struct{}
-
-func (a approver) Authorize(ctx context.Context, auth authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
-	return authorizer.DecisionAllow, "user allowed", nil
-}
-
-type given struct {
-	req        *http.Request
-	authorizer authorizer.Authorizer
-}
-
-type expected struct {
-	status     int
-	verifyUser bool
-}
-
-type testCase struct {
-	given
-	expected
-	description string
 }


### PR DESCRIPTION
# What

Move auth logic out of proxy as filter.

# Why

- Streamline the logic to be more similar to K8s
- So it ca be replaced
- Is easier understandable
- Is testable and tested