### PR TITLE
feat: Skip upstream certificate validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ Usage of _output/kube-rbac-proxy:
       --tls-private-key-file string                 File containing the default x509 private key matching --tls-cert-file.
       --tls-reload-interval duration                The interval at which to watch for TLS certificate changes, by default set to 1 minute. (default 1m0s)
       --upstream string                             The upstream URL to proxy to once requests have successfully been authenticated and authorized.
-      --upstream-ca-file string                     The CA the upstream uses for TLS connection. This is required when the upstream uses TLS and its own CA certificate
-      --upstream-force-h2c                          Force h2c to communiate with the upstream. This is required when the upstream speaks h2c(http/2 cleartext - insecure variant of http/2) only. For example, go-grpc server in the insecure mode, such as helm's tiller w/o TLS, speaks h2c only
+      --upstream-ca-file string                     The CA the upstream uses for TLS connection. This is required when the upstream uses TLS and its own CA certificate.
+      --upstream-force-h2c                          Force h2c to communicate with the upstream. This is required when the upstream speaks h2c(http/2 cleartext - insecure variant of http/2) only. For example, go-grpc server in the insecure mode, such as helm's tiller w/o TLS, speaks h2c only.
+      --upstream-insecure-skip-verify               Skip upstream certificate validation. Useful if an upstream uses TLS encryption with self-signed certificates.
   -v, --v Level                                     number for the log level verbosity
       --vmodule moduleSpec                          comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/transport.go
+++ b/transport.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -25,37 +26,53 @@ import (
 	"net/http"
 	"os"
 	"time"
+
+	"golang.org/x/net/http2"
 )
 
-func initTransport(upstreamCAFile string) (http.RoundTripper, error) {
-	if upstreamCAFile == "" {
-		return http.DefaultTransport, nil
-	}
-
-	rootPEM, err := os.ReadFile(upstreamCAFile)
-	if err != nil {
-		return nil, fmt.Errorf("error reading upstream CA file: %v", err)
+func initTransport(upstream upstreamConfig) (http.RoundTripper, error) {
+	// Force http/2 for connections to the upstream i.e. do not start with HTTP1.1 UPGRADE req to
+	// initialize http/2 session.
+	// See https://github.com/golang/go/issues/14141#issuecomment-219212895 for more context
+	if upstream.forceH2C {
+		return &http2.Transport{
+			// Allow http schema. This doesn't automatically disable TLS
+			AllowHTTP: true,
+			// Do disable TLS.
+			// In combination with the schema check above. We could enforce h2c against the upstream server
+			DialTLSContext: func(ctx context.Context, netw, addr string, cfg *tls.Config) (net.Conn, error) {
+				return net.Dial(netw, addr)
+			},
+		}, nil
 	}
 
 	roots := x509.NewCertPool()
-	if ok := roots.AppendCertsFromPEM([]byte(rootPEM)); !ok {
-		return nil, errors.New("error parsing upstream CA certificate")
+
+	if upstream.caFile != "" {
+		rootPEM, err := os.ReadFile(upstream.caFile)
+		if err != nil {
+			return nil, fmt.Errorf("error reading upstream CA file: %v", err)
+		}
+
+		if ok := roots.AppendCertsFromPEM(rootPEM); !ok {
+			return nil, errors.New("error parsing upstream CA certificate")
+		}
 	}
 
-	// http.Transport sourced from go 1.10.7
-	transport := &http.Transport{
+	// http.Transport sourced from go 1.19
+	return &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
-			DualStack: true,
 		}).DialContext,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-		TLSClientConfig:       &tls.Config{RootCAs: roots},
-	}
-
-	return transport, nil
+		TLSClientConfig: &tls.Config{
+			RootCAs:            roots,
+			InsecureSkipVerify: upstream.insecureSkipVerify,
+		},
+	}, nil
 }


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Motivation

A proxy always comes in front of upstream. Some upstream, instead of HTTP requests, serve HTTPS requests with self-signed certificates (this is better than having no TLS at all).

## Additional information

I also moved all transport-related code pieces to the `transport.go`.