### PR TITLE
Support upstream via unix socket

### DIFF
--- a/cmd/kube-rbac-proxy/app/options/options.go
+++ b/cmd/kube-rbac-proxy/app/options/options.go
@@ -35,7 +35,7 @@ type ProxyRunOptions struct {
 
 	Upstream           string
 	UpstreamForceH2C   bool
-	UpstreamCAFile     string
+	UpstreamUnixSocket string
 	Auth               *proxy.Config
 	TLS                *TLSConfig
 	KubeconfigLocation string
@@ -50,6 +50,7 @@ type TLSConfig struct {
 	CipherSuites   []string
 	ReloadInterval time.Duration
 
+	UpstreamCAFile         string
 	UpstreamClientCertFile string
 	UpstreamClientKeyFile  string
 }
@@ -78,7 +79,7 @@ func (o *ProxyRunOptions) Flags() k8sapiflag.NamedFlagSets {
 	flagset.StringVar(&o.SecureListenAddress, "secure-listen-address", "", "The address the kube-rbac-proxy HTTPs server should listen on.")
 	flagset.StringVar(&o.Upstream, "upstream", "", "The upstream URL to proxy to once requests have successfully been authenticated and authorized.")
 	flagset.BoolVar(&o.UpstreamForceH2C, "upstream-force-h2c", false, "Force h2c to communiate with the upstream. This is required when the upstream speaks h2c(http/2 cleartext - insecure variant of http/2) only. For example, go-grpc server in the insecure mode, such as helm's tiller w/o TLS, speaks h2c only")
-	flagset.StringVar(&o.UpstreamCAFile, "upstream-ca-file", "", "The CA the upstream uses for TLS connection. This is required when the upstream uses TLS and its own CA certificate")
+	flagset.StringVar(&o.UpstreamUnixSocket, "upstream-unix-socket", "", "The upstream unix socket to proxy to once requests have successfully been authenticated and authorized.")
 	flagset.StringVar(&o.ConfigFileName, "config-file", "", "Configuration file to configure kube-rbac-proxy.")
 	flagset.StringSliceVar(&o.AllowPaths, "allow-paths", nil, "Comma-separated list of paths against which kube-rbac-proxy pattern-matches the incoming request. If the request doesn't match, kube-rbac-proxy responds with a 404 status code. If omitted, the incoming request path isn't checked. Cannot be used with --ignore-paths.")
 	flagset.StringSliceVar(&o.IgnorePaths, "ignore-paths", nil, "Comma-separated list of paths against which kube-rbac-proxy pattern-matches the incoming request. If the requst matches, it will proxy the request without performing an authentication or authorization check. Cannot be used with --allow-paths.")
@@ -90,6 +91,7 @@ func (o *ProxyRunOptions) Flags() k8sapiflag.NamedFlagSets {
 	flagset.StringVar(&o.TLS.MinVersion, "tls-min-version", "VersionTLS12", "Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants.")
 	flagset.StringSliceVar(&o.TLS.CipherSuites, "tls-cipher-suites", nil, "Comma-separated list of cipher suites for the server. Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants). If omitted, the default Go cipher suites will be used")
 	flagset.DurationVar(&o.TLS.ReloadInterval, "tls-reload-interval", time.Minute, "The interval at which to watch for TLS certificate changes, by default set to 1 minute.")
+	flagset.StringVar(&o.TLS.UpstreamCAFile, "upstream-ca-file", "", "The CA the upstream uses for TLS connection. This is required when the upstream uses TLS and its own CA certificate")
 	flagset.StringVar(&o.TLS.UpstreamClientCertFile, "upstream-client-cert-file", "", "If set, the client will be used to authenticate the proxy to upstream. Requires --upstream-client-key-file to be set, too.")
 	flagset.StringVar(&o.TLS.UpstreamClientKeyFile, "upstream-client-key-file", "", "The key matching the certificate from --upstream-client-cert-file. If set, requires --upstream-client-cert-file to be set, too.")
 


### PR DESCRIPTION
Add support for the proxing to the upstream via a unix socket. This may help to reduce the number of the ports occupied by the POD which uses `kube-rbac-proxy` (e.g. when POD uses `hostnetwork`).

Test PR whose e2e targets a POD's container endpoint via `kube-rbac-proxy`: https://github.com/openshift/node-observability-operator/pull/113

Manual test:
```
# start upstream which listens on unix socket
$ ./bin/node-observability-agent -unixSocket /tmp/nobagent.sock -preferUnixSocket -crioPreferUnixSocket=false -caCertFile=kubelet.crt -tokenFile=token
INFO[0000] Starting node-observability-agent version: "v0.0.0-unknown", commit: "da7d110", build date: "2022-11-16T09:16:10Z", go version: "go1.19.2", GOOS: "linux", GOARCH: "amd64" at log level info 
INFO[0000] Start listening on unix:///tmp/nobagent.sock  module=server
INFO[0000] Targeting node 192.168.130.11                 module=server

$ sudo ss -lxp | grep node
u_str LISTEN 0      128                                                                /tmp/nobagent.sock 297621            * 0      users:(("node-observabil",pid=95712,fd=3)) 

# start kube-rbac-proxy
$ ./_output/kube-rbac-proxy --kubeconfig=/home/alebedev/.crc/machines/crc/kubeconfig --upstream-unix-socket=/tmp/nobagent.sock --secure-listen-address=0.0.0.0:8443 --tls-cert-file=tls.crt --tls-private-key-file=tls.key
I1116 10:52:57.726306   95991 main.go:209] Valid token audiences: 
I1116 10:52:57.726524   95991 main.go:355] Reading certificate files
I1116 10:52:57.726751   95991 main.go:389] Starting TCP socket on 0.0.0.0:8443
I1116 10:52:57.734420   95991 main.go:396] Listening securely on 0.0.0.0:8443

# send request via proxy
$ curl -k -H "Authorization: Bearer ${TOKEN}" https://localhost:8443/node-observability-status
Service is ready

# see the logs of the upstream to verify it got the request
$ ./bin/node-observability-agent -unixSocket /tmp/nobagent.sock -preferUnixSocket -crioPreferUnixSocket=false -caCertFile=kubelet.crt -tokenFile=token
INFO[0000] Starting node-observability-agent version: "v0.0.0-unknown", commit: "da7d110", build date: "2022-11-16T09:16:10Z", go version: "go1.19.2", GOOS: "linux", GOARCH: "amd64" at log level info 
INFO[0000] Start listening on unix:///tmp/nobagent.sock  module=server
INFO[0000] Targeting node 192.168.130.11                 module=server
INFO[0100] start handling status request                 module=handler
INFO[0100] agent is ready                                module=handler
```