### PR TITLE
Bump golang version to 1.19.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   QUAY_PATH: quay.io/brancz/kube-rbac-proxy
-  go-version: '1.19.1'
+  go-version: '1.19.4'
   kind-version: 'v0.16.0'
 
 jobs:


### PR DESCRIPTION
Bump golang version to 1.19.4. 
This should fix couple of different CVEs found in older golang versions. 