### PR TITLE
Accept Multi Values in One Header When Using byHttpHeader

### DIFF
--- a/pkg/authz/auth.go
+++ b/pkg/authz/auth.go
@@ -53,6 +53,7 @@ type QueryParameterRewriteConfig struct {
 // be used to rewrite a SubjectAccessReview on a given request.
 type HTTPHeaderRewriteConfig struct {
 	Name string `json:"name,omitempty"`
+	Sep  string `json:"separator,omitempty"`
 }
 
 // ResourceAttributes describes attributes available for resource request authorization

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"net/http"
 	"net/textproto"
+	"strings"
 	"text/template"
 
 	"github.com/brancz/kube-rbac-proxy/pkg/authn"
@@ -109,6 +110,10 @@ func (n krpAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *http
 		mimeHeader := textproto.MIMEHeader(r.Header)
 		mimeKey := textproto.CanonicalMIMEHeaderKey(n.authzConfig.Rewrites.ByHTTPHeader.Name)
 		if ps, ok := mimeHeader[mimeKey]; ok {
+			if n.authzConfig.Rewrites.ByHTTPHeader.Sep != "" {
+				ps = splitHeader(ps, n.authzConfig.Rewrites.ByHTTPHeader.Sep)
+			}
+
 			params = append(params, ps...)
 		}
 	}
@@ -142,4 +147,15 @@ func templateWithValue(templateString, value string) string {
 		return ""
 	}
 	return out.String()
+}
+
+func splitHeader(headers []string, sep string) []string {
+	splitted := []string{}
+
+	for i := range headers {
+		temp := strings.Split(headers[i], sep)
+		splitted = append(splitted, temp...)
+	}
+
+	return splitted
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -150,12 +150,12 @@ func templateWithValue(templateString, value string) string {
 }
 
 func splitHeader(headers []string, sep string) []string {
-	splitted := []string{}
+	split := []string{}
 
 	for i := range headers {
 		temp := strings.Split(headers[i], sep)
-		splitted = append(splitted, temp...)
+		split = append(split, temp...)
 	}
 
-	return splitted
+	return split
 }

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -154,6 +154,38 @@ func TestGeneratingAuthorizerAttributes(t *testing.T) {
 			},
 		},
 		{
+			"with http header rewrites config and separator",
+			&authz.Config{
+				Rewrites:           &authz.SubjectAccessReviewRewrites{ByHTTPHeader: &authz.HTTPHeaderRewriteConfig{Name: "namespace", Sep: "|"}},
+				ResourceAttributes: &authz.ResourceAttributes{Namespace: "{{ .Value }}", APIVersion: "v1", Resource: "namespace", Subresource: "metrics"},
+			},
+			createRequest(nil, map[string][]string{"namespace": {"tenant1|tenant2"}}),
+			[]authorizer.Attributes{
+				authorizer.AttributesRecord{
+					User:            nil,
+					Verb:            "get",
+					Namespace:       "tenant1",
+					APIGroup:        "",
+					APIVersion:      "v1",
+					Resource:        "namespace",
+					Subresource:     "metrics",
+					Name:            "",
+					ResourceRequest: true,
+				},
+				authorizer.AttributesRecord{
+					User:            nil,
+					Verb:            "get",
+					Namespace:       "tenant2",
+					APIGroup:        "",
+					APIVersion:      "v1",
+					Resource:        "namespace",
+					Subresource:     "metrics",
+					Name:            "",
+					ResourceRequest: true,
+				},
+			},
+		},
+		{
 			"with http header rewrites config but missing header",
 			&authz.Config{
 				Rewrites:           &authz.SubjectAccessReviewRewrites{ByQueryParameter: &authz.QueryParameterRewriteConfig{Name: "namespace"}},


### PR DESCRIPTION
### Description
This PR extends the feature in https://github.com/brancz/kube-rbac-proxy/pull/104. With a "separator" in the config the header value can be split.

e.g.

```
"authorization":
  "resourceAttributes":
    "apiVersion": "metrics.k8s.io/v1beta1"
    "namespace": "{{ .Value }}"
    "resource": "pods"
  "rewrites":
    "byHttpHeader":
      "name": "X-Scope-OrgID"
      "separator": "|"
```

### Motivation
We also put kube-rbac-proxy in front of Loki (https://grafana.com/docs/loki/latest/). And Loki 2.6 enabled multi-tenant queries: https://grafana.com/blog/2022/07/27/grafana-loki-2.6-release/

The required format from loki is like this:
```
curl -H 'X-Scope-OrgID:Tenant1|Tenant2|Tenant3' \
  -G -s "http://localhost:3100/loki/api/v1/query" \
  --data-urlencode \
  'query=sum(rate({job="varlogs"}[10m])) by (level)' | jq
```