### PR TITLE
Use formatted logging function

### DIFF
--- a/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
+++ b/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
@@ -454,7 +454,7 @@ func Run(cfg *completedProxyRunOptions) error {
 					}
 					defer proxyListener.Close()
 
-					klog.Info("Listening securely on %v for proxy endpoints", endpointsAddr)
+					klog.Infof("Listening securely on %v for proxy endpoints", endpointsAddr)
 					tlsListener := tls.NewListener(proxyListener, srv.TLSConfig)
 					return proxyEndpointsSrv.Serve(tlsListener)
 				}, func(err error) {


### PR DESCRIPTION
The `endpointsAddr` variable is now properly formatted in the log message