### PR TITLE
Makefile: make local testing work with one command

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,10 @@ Additionally, to my knowledge Envoy neither has nor plans Kubernetes specific RB
 
 ## Testing
 
-To run tests locally, you need to have [kind](https://kind.sigs.k8s.io/) installed. By default it uses the default cluster, so be aware that it might override your default cluster.
+To run tests locally, you need to have [kind](https://kind.sigs.k8s.io/) installed.
+By default it uses the default cluster, so be aware that **it overrides your default kind cluster**.
 
-The command to execute the tests is: `VERSION=local make clean container kind-create-cluster test`.
+The command to execute the tests is: `make test-local`.
 
 ## Roadmap
 


### PR DESCRIPTION
## What

Make `make test-local` work and on other architectures as well.

## Why

Currently `make test-local` prints only what needs to be done and it only works on Linux-AMD64.