### PR TITLE
bump up go version to 1.20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   QUAY_PATH: quay.io/brancz/kube-rbac-proxy
-  go-version: '1.19.4'
+  go-version: '1.20.4'
   kind-version: 'v0.16.0'
 
 jobs:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brancz/kube-rbac-proxy
 
-go 1.19
+go 1.20
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
This PR updates go lang version in go.mo to 1.20.
It fixes following High Level CVEs:

- [CVE-2023-24534](https://nvd.nist.gov/vuln/detail/CVE-2023-24534)
- [CVE-2023-24536](https://nvd.nist.gov/vuln/detail/CVE-2023-24536)