### PR TITLE
propagate GOOS to docker container build in test local setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 ARG GOARCH=amd64
+ARG GOOS=linux
 FROM gcr.io/distroless/static:nonroot-$GOARCH
 
-ARG BINARY=kube-rbac-proxy-linux-amd64
+ARG BINARY=kube-rbac-proxy-$GOOS-$GOARCH
 COPY _output/$BINARY /usr/local/bin/kube-rbac-proxy
 EXPOSE 8080
 USER 65532:65532

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,9 @@ test-e2e:
 	go test -timeout 55m -v ./test/e2e/ $(TEST_RUN_ARGS) --kubeconfig=$(KUBECONFIG)
 
 test-local-setup: clean $(OUT_DIR)/$(BIN)-$(GOOS)-$(GOARCH) Dockerfile
-	docker build --build-arg BINARY=$(BIN)-$(GOOS)-$(GOARCH) --build-arg GOARCH=$(GOARCH) -t $(CONTAINER_NAME)-$(GOARCH) .
+	docker build --build-arg BINARY=$(BIN)-$(GOOS)-$(GOARCH) \
+	  --build-arg GOOS=$(GOOS) --build-arg GOARCH=$(GOARCH) \
+	  -t $(CONTAINER_NAME)-$(GOARCH) .
 	docker tag $(DOCKER_REPO):$(VERSION)-$(GOARCH) $(DOCKER_REPO):local
 
 test-local: test-local-setup kind-create-cluster test


### PR DESCRIPTION
This PR propagates the GOOS environment variable to the docker build fixing the issue on macOS arm64 platform.
