### PR TITLE
Minor improvements in cmd/kube-rbac-proxy

### DIFF
--- a/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
+++ b/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
@@ -92,14 +92,7 @@ that can perform RBAC authorization against the Kubernetes API using SubjectAcce
 
 			return Run(completedOptions)
 		},
-		Args: func(cmd *cobra.Command, args []string) error {
-			for _, arg := range args {
-				if len(arg) > 0 {
-					return fmt.Errorf("%q does not take any arguments, got %q", cmd.CommandPath(), args)
-				}
-			}
-			return nil
-		},
+		Args: cobra.NoArgs,
 	}
 
 	fs := cmd.Flags()


### PR DESCRIPTION
This PR addresses some of the issues from #238; in particular, the ones listed in [this comment](https://github.com/brancz/kube-rbac-proxy/issues/238#issuecomment-1571662143).

In particular:
- (3) Replace func with cobra.Args [link](https://github.com/brancz/kube-rbac-proxy/pull/229/files#diff-8796db11a6b137095413f7a7109dd01393e63d425454fc04647b98d2b8c0115cR106): see 71da752a034bed8df7d4b9da410bd61de4c9f2d1
- (4) Run should run with a final config version. Complete should finish the necessary changes and those shouldn't happen anymore in Run. [link](https://github.com/brancz/kube-rbac-proxy/pull/229/files#diff-8796db11a6b137095413f7a7109dd01393e63d425454fc04647b98d2b8c0115cR166): see b410b9693c63eef2181097da627df19c1c88a338
- (5) Use context from Signals. [link](https://github.com/brancz/kube-rbac-proxy/pull/229/files#diff-8796db11a6b137095413f7a7109dd01393e63d425454fc04647b98d2b8c0115cR171): see 0c10f9caf132baa2cee91219cb4c8ba7de6f4b24
- (10) Describe what an empty request info factory means [link](https://github.com/brancz/kube-rbac-proxy/pull/229/files#diff-8796db11a6b137095413f7a7109dd01393e63d425454fc04647b98d2b8c0115cR217): see c68149625dd689704e8b51b83c3a16fa2b5be1d3
- (11) Use safe wait group from k/k instead of run.Group [link](https://github.com/brancz/kube-rbac-proxy/pull/229/files#diff-8796db11a6b137095413f7a7109dd01393e63d425454fc04647b98d2b8c0115cR223)
- (13) Comment why we have two listeners on different ports [link](https://github.com/brancz/kube-rbac-proxy/pull/229/files#diff-8796db11a6b137095413f7a7109dd01393e63d425454fc04647b98d2b8c0115cR232): see b410b9693c63eef2181097da627df19c1c88a338
- (15) Add serverconfig.SetupSignalContext [link](https://github.com/brancz/kube-rbac-proxy/pull/229/files#diff-8796db11a6b137095413f7a7109dd01393e63d425454fc04647b98d2b8c0115cR242-R243): see 0c10f9caf132baa2cee91219cb4c8ba7de6f4b24
- (17) Authorizers should only be added, when used [link](https://github.com/brancz/kube-rbac-proxy/pull/229/files#diff-8796db11a6b137095413f7a7109dd01393e63d425454fc04647b98d2b8c0115cL317-R329): see a24945c11cd8fef7f01e56924a91281b6211fe1e
- (18) Verify that Rewrite Attributes is definitely turned off if not configured [link](https://github.com/brancz/kube-rbac-proxy/pull/229/files#diff-8796db11a6b137095413f7a7109dd01393e63d425454fc04647b98d2b8c0115cR314): see a24945c11cd8fef7f01e56924a91281b6211fe1e