### PR TITLE
Rewrite rewrite authorizer impl

### DIFF
--- a/cmd/kube-rbac-proxy/app/options/proxyoptions.go
+++ b/cmd/kube-rbac-proxy/app/options/proxyoptions.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/brancz/kube-rbac-proxy/pkg/authn/identityheaders"
 	authz "github.com/brancz/kube-rbac-proxy/pkg/authorization"
+	"github.com/brancz/kube-rbac-proxy/pkg/authorization/rewrite"
 	"github.com/brancz/kube-rbac-proxy/pkg/server"
 )
 
@@ -146,6 +147,12 @@ func parseAuthorizationConfigFile(filePath string) (*authz.AuthzConfig, error) {
 
 	if err := yaml.Unmarshal(b, &configFile); err != nil {
 		return nil, fmt.Errorf("failed to parse config file content: %w", err)
+	}
+
+	// If RewriteAttributesConfig is not set, set it to an empty config.
+	// This is to avoid nil plenty of pointer dereference checks further down.
+	if configFile.AuthorizationConfig.RewriteAttributesConfig == nil {
+		configFile.AuthorizationConfig.RewriteAttributesConfig = &rewrite.RewriteAttributesConfig{}
 	}
 
 	return configFile.AuthorizationConfig, nil

--- a/cmd/kube-rbac-proxy/app/options/proxyoptions_test.go
+++ b/cmd/kube-rbac-proxy/app/options/proxyoptions_test.go
@@ -104,6 +104,7 @@ func Test_parseAuthorizationConfigFile(t *testing.T) {
 						Path:            "/metrics",
 					},
 				},
+				RewriteAttributesConfig: &rewrite.RewriteAttributesConfig{},
 			},
 		},
 	}

--- a/pkg/authorization/rewrite/attributes.go
+++ b/pkg/authorization/rewrite/attributes.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2023 the kube-rbac-proxy maintainers. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package rewrite
+
+import (
+	"bytes"
+	"context"
+	"text/template"
+
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+// AttributesGenerator is a an interface for generating a list of attributes.
+// Attributes must be adjusted dependant on the configuration and context.
+type AttributesGenerator interface {
+	Generate(context.Context, authorizer.Attributes) []authorizer.Attributes
+}
+
+// NonResourceAttributesGenerator reduces a given attribute to user and http based
+// attributes.
+type NonResourceAttributesGenerator struct{}
+
+var _ AttributesGenerator = &NonResourceAttributesGenerator{}
+
+// Generate reduces the original attributes to user and http based attributes.
+func (d *NonResourceAttributesGenerator) Generate(ctx context.Context, attr authorizer.Attributes) []authorizer.Attributes {
+	return []authorizer.Attributes{
+		authorizer.AttributesRecord{
+			User:            attr.GetUser(),
+			Verb:            attr.GetVerb(),
+			ResourceRequest: false,
+			Path:            attr.GetPath(),
+		},
+	}
+}
+
+// BoundAttributesGenerator uses the given attributes' user and http verb and
+// verifies its authorization against a predefined kubernetes resource. The
+// authorization is bound to that given kubernetes resource.
+type BoundAttributesGenerator struct {
+	attributes *ResourceAttributes
+}
+
+var _ AttributesGenerator = &BoundAttributesGenerator{}
+
+// NewResourceAttributesGenerator creates a BoundAttributesGenerator.
+func NewResourceAttributesGenerator(attributes *ResourceAttributes) *BoundAttributesGenerator {
+	return &BoundAttributesGenerator{
+		attributes: attributes,
+	}
+}
+
+// Generate maps the given attributes user and verb to a predefined kubernetes
+// resource.
+func (b *BoundAttributesGenerator) Generate(ctx context.Context, attr authorizer.Attributes) []authorizer.Attributes {
+	return []authorizer.Attributes{
+		authorizer.AttributesRecord{
+			User:            attr.GetUser(),
+			Verb:            attr.GetVerb(),
+			Namespace:       b.attributes.Namespace,
+			APIGroup:        b.attributes.APIGroup,
+			APIVersion:      b.attributes.APIVersion,
+			Resource:        b.attributes.Resource,
+			Subresource:     b.attributes.Subresource,
+			Name:            b.attributes.Name,
+			ResourceRequest: true,
+		},
+	}
+}
+
+// RewritingAttributesGenerator uses the given attributes' user and http verb
+// and verifies its authorization against a predefined kubernetes resource
+// template. The template is rewritting using client input data, which is VERY
+// DANGEROUS. It should only be used in a narrow use-case, where the upstream
+// is interpreting the input data as well.
+type RewritingAttributesGenerator struct {
+	attributes *ResourceAttributes
+
+	namespace   *template.Template
+	apiGroup    *template.Template
+	apiVersion  *template.Template
+	resource    *template.Template
+	subresource *template.Template
+	name        *template.Template
+}
+
+var _ AttributesGenerator = &RewritingAttributesGenerator{}
+
+// NewTemplatedResourceAttributesGenerator returns a RewritingAttributesGenerator.
+func NewTemplatedResourceAttributesGenerator(attributes *ResourceAttributes) *RewritingAttributesGenerator {
+	return &RewritingAttributesGenerator{
+		attributes: attributes,
+
+		namespace:   template.Must(template.New("namespace").Parse(attributes.Namespace)),
+		apiGroup:    template.Must(template.New("apiGroup").Parse(attributes.APIGroup)),
+		apiVersion:  template.Must(template.New("apiVersion").Parse(attributes.APIVersion)),
+		resource:    template.Must(template.New("resource").Parse(attributes.Resource)),
+		subresource: template.Must(template.New("subresource").Parse(attributes.Subresource)),
+		name:        template.Must(template.New("name").Parse(attributes.Name)),
+	}
+}
+
+// Generate maps the given attributes and context against a pre-defined kubernetes
+// resource template. The template is rewritting using client input data, which
+// is VERY DANGEROUS. It should only be used in a narrow use-case, where the
+// upstream is interpreting the input data as well.
+func (r *RewritingAttributesGenerator) Generate(ctx context.Context, attr authorizer.Attributes) []authorizer.Attributes {
+	params := getKubeRBACProxyParams(ctx)
+	if len(params) == 0 {
+		return nil
+	}
+
+	attrs := []authorizer.Attributes{}
+	for _, param := range params {
+		attrs = append(attrs,
+			authorizer.AttributesRecord{
+				User:            attr.GetUser(),
+				Verb:            attr.GetVerb(),
+				Namespace:       templateWithValue(r.namespace, param),
+				APIGroup:        templateWithValue(r.apiGroup, param),
+				APIVersion:      templateWithValue(r.apiVersion, param),
+				Resource:        templateWithValue(r.resource, param),
+				Subresource:     templateWithValue(r.subresource, param),
+				Name:            templateWithValue(r.name, param),
+				ResourceRequest: true,
+			})
+	}
+
+	if len(attrs) == 0 {
+		// If there are no params, we want to minimize the probability to run insecurely.
+		return nil
+	}
+
+	return attrs
+}
+
+func templateWithValue(tmpl *template.Template, value string) string {
+	out := bytes.NewBuffer(nil)
+	err := tmpl.Execute(out, struct{ Value string }{Value: value})
+	if err != nil {
+		return ""
+	}
+	return out.String()
+}

--- a/pkg/authorization/rewrite/attributes_test.go
+++ b/pkg/authorization/rewrite/attributes_test.go
@@ -1,0 +1,360 @@
+/*
+Copyright 2023 the kube-rbac-proxy maintainers. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package rewrite_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/brancz/kube-rbac-proxy/pkg/authorization/rewrite"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+func TestDefaultAttributesGenerator(t *testing.T) {
+	generator := &rewrite.NonResourceAttributesGenerator{}
+	testCases := []struct {
+		name       string
+		attributes authorizer.AttributesRecord
+		expected   authorizer.AttributesRecord
+	}{
+		{
+			name: "basic HTTP attributes",
+			attributes: authorizer.AttributesRecord{
+				User:            &user.DefaultInfo{Name: "test user 0"},
+				Verb:            "post",
+				Namespace:       "",
+				APIGroup:        "",
+				APIVersion:      "",
+				Resource:        "",
+				Subresource:     "",
+				Name:            "",
+				ResourceRequest: false,
+				Path:            "/api/v1/users",
+			},
+			expected: authorizer.AttributesRecord{
+				User:            &user.DefaultInfo{Name: "test user 0"},
+				Verb:            "post",
+				Namespace:       "",
+				APIGroup:        "",
+				APIVersion:      "",
+				Resource:        "",
+				Subresource:     "",
+				Name:            "",
+				ResourceRequest: false,
+				Path:            "/api/v1/users",
+			},
+		},
+		{
+			name: "basic attributes",
+			attributes: authorizer.AttributesRecord{
+				User:            &user.DefaultInfo{Name: "test user 1"},
+				Verb:            "get",
+				Namespace:       "default",
+				APIGroup:        "",
+				APIVersion:      "",
+				Resource:        "pods",
+				Subresource:     "",
+				Name:            "",
+				ResourceRequest: false,
+				Path:            "/api/v1/namespaces/default/pods",
+			},
+			expected: authorizer.AttributesRecord{
+				User:            &user.DefaultInfo{Name: "test user 1"},
+				Verb:            "get",
+				Namespace:       "",
+				APIGroup:        "",
+				APIVersion:      "",
+				Resource:        "",
+				Subresource:     "",
+				Name:            "",
+				ResourceRequest: false,
+				Path:            "/api/v1/namespaces/default/pods",
+			},
+		},
+		{
+			name: "attributes with subresource",
+			attributes: authorizer.AttributesRecord{
+				User:            &user.DefaultInfo{Name: "test user 2"},
+				Verb:            "update",
+				Namespace:       "default",
+				APIGroup:        "",
+				APIVersion:      "",
+				Resource:        "pods",
+				Subresource:     "status",
+				Name:            "pod1",
+				ResourceRequest: false,
+				Path:            "/api/v1/namespaces/default/pods/pod1/status",
+			},
+			expected: authorizer.AttributesRecord{
+				User:            &user.DefaultInfo{Name: "test user 2"},
+				Verb:            "update",
+				Namespace:       "",
+				APIGroup:        "",
+				APIVersion:      "",
+				Resource:        "",
+				Subresource:     "",
+				Name:            "",
+				ResourceRequest: false,
+				Path:            "/api/v1/namespaces/default/pods/pod1/status",
+			},
+		},
+		{
+			name: "resource request attributes",
+			attributes: authorizer.AttributesRecord{
+				User:            &user.DefaultInfo{Name: "test user 3"},
+				Verb:            "get",
+				Namespace:       "default",
+				APIGroup:        "",
+				APIVersion:      "",
+				Resource:        "pods",
+				Subresource:     "",
+				Name:            "",
+				ResourceRequest: true,
+				Path:            "/api/v1/namespaces/default/pods",
+			},
+			expected: authorizer.AttributesRecord{
+				User:            &user.DefaultInfo{Name: "test user 3"},
+				Verb:            "get",
+				Namespace:       "",
+				APIGroup:        "",
+				APIVersion:      "",
+				Resource:        "",
+				Subresource:     "",
+				Name:            "",
+				ResourceRequest: false,
+				Path:            "/api/v1/namespaces/default/pods",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			generatedAttributes := generator.Generate(context.Background(), tc.attributes)
+
+			if len(generatedAttributes) != 1 {
+				t.Errorf("Expected 1 generated attribute, but got %d", len(generatedAttributes))
+			}
+
+			generatedRecord := generatedAttributes[0]
+			if !reflect.DeepEqual(generatedRecord, tc.expected) {
+				t.Errorf(
+					"Generated attribute does not match expected attribute.\nHave: %+v,\nWant: %+v",
+					generatedRecord, tc.expected,
+				)
+			}
+		})
+	}
+}
+
+func TestBoundAttributesGenerator(t *testing.T) {
+	boundResource := &rewrite.ResourceAttributes{
+		Namespace:  "kube-system",
+		APIGroup:   "core",
+		APIVersion: "v1",
+		Resource:   "pods",
+		Name:       "kube-apiserver",
+	}
+
+	defaultUser := &user.DefaultInfo{Name: "bound test user"}
+	expectedAttributes := func(verb string) authorizer.Attributes {
+		return authorizer.AttributesRecord{
+			User:            defaultUser,
+			Verb:            verb,
+			Namespace:       boundResource.Namespace,
+			APIGroup:        boundResource.APIGroup,
+			APIVersion:      boundResource.APIVersion,
+			Resource:        boundResource.Resource,
+			Subresource:     boundResource.Subresource,
+			Name:            boundResource.Name,
+			ResourceRequest: true,
+		}
+	}
+
+	testCases := []struct {
+		name     string
+		input    authorizer.Attributes
+		expected authorizer.Attributes
+	}{
+		{
+			name: "simple HTTP attributes",
+			input: authorizer.AttributesRecord{
+				User:            defaultUser,
+				Verb:            "get",
+				Namespace:       "default",
+				APIGroup:        "",
+				APIVersion:      "",
+				Resource:        "pods",
+				Subresource:     "",
+				Name:            "",
+				ResourceRequest: false,
+				Path:            "/api/v1/namespaces/default/pods",
+			},
+			expected: expectedAttributes("get"),
+		},
+		{
+			name: "normal k8s attributes",
+			input: authorizer.AttributesRecord{
+				User:            defaultUser,
+				Verb:            "get",
+				Namespace:       "default",
+				APIGroup:        "core",
+				APIVersion:      "v1",
+				Resource:        "pods",
+				Subresource:     "",
+				Name:            "",
+				ResourceRequest: true,
+				Path:            "/api/v1/namespaces/default/pods",
+			},
+			expected: expectedAttributes("get"),
+		},
+		{
+			name: "subresource attributes",
+			input: authorizer.AttributesRecord{
+				User:            defaultUser,
+				Verb:            "update",
+				Namespace:       "default",
+				APIGroup:        "",
+				APIVersion:      "",
+				Resource:        "pods",
+				Subresource:     "status",
+				Name:            "pod1",
+				ResourceRequest: false,
+				Path:            "/api/v1/namespaces/default/pods/pod1/status",
+			},
+			expected: expectedAttributes("update"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			attrGen := rewrite.NewResourceAttributesGenerator(boundResource)
+			results := attrGen.Generate(context.Background(), tc.input)
+			if len(results) != 1 {
+				t.Errorf("Expected 1 generated attribute, but got %d", len(results))
+			}
+			result := results[0]
+
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("Unexpected result. \nHave: %q, \nWant: %q", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestRewritingAttributesGenerator(t *testing.T) {
+	templateResource := &rewrite.ResourceAttributes{
+		Namespace:  "{{ .Value }}",
+		APIGroup:   "core",
+		APIVersion: "v1",
+		Resource:   "namespace",
+	}
+
+	defaultUser := &user.DefaultInfo{Name: "bound test user"}
+	expectedAttributes := func(verb string, namespaces []string) []authorizer.Attributes {
+		var attrs []authorizer.Attributes
+		for _, namespace := range namespaces {
+			attrs = append(attrs, authorizer.AttributesRecord{
+				User:            defaultUser,
+				Verb:            verb,
+				Namespace:       namespace,
+				APIGroup:        templateResource.APIGroup,
+				APIVersion:      templateResource.APIVersion,
+				Resource:        templateResource.Resource,
+				Subresource:     templateResource.Subresource,
+				Name:            templateResource.Name,
+				ResourceRequest: true,
+			})
+		}
+
+		return attrs
+	}
+
+	testCase := []struct {
+		name   string
+		params []string
+		input  authorizer.Attributes
+		output []authorizer.Attributes
+	}{
+		{
+			name:   "with one param (hacked)",
+			params: []string{"kube-system"},
+			input: authorizer.AttributesRecord{
+				User:            defaultUser,
+				Verb:            "post",
+				Namespace:       "admin",
+				APIGroup:        "core",
+				APIVersion:      "v1",
+				Resource:        "pods",
+				Subresource:     "trojan",
+				Name:            "hack-pod",
+				ResourceRequest: true,
+				Path:            "/api/v1/namespaces/admin/pods/hack-pod",
+			},
+			output: expectedAttributes("post", []string{"kube-system"}),
+		},
+		{
+			name:   "with no param",
+			params: []string{},
+			input: authorizer.AttributesRecord{
+				User:            defaultUser,
+				Verb:            "post",
+				Namespace:       "admin",
+				APIGroup:        "core",
+				APIVersion:      "v1",
+				Resource:        "pods",
+				Subresource:     "trojan",
+				Name:            "hack-pod",
+				ResourceRequest: true,
+				Path:            "/api/v1/namespaces/admin/pods",
+			},
+			output: nil,
+		},
+		{
+			name:   "with multiple params",
+			params: []string{"kube-system", "default"},
+			input: authorizer.AttributesRecord{
+				User:            defaultUser,
+				Verb:            "get",
+				Namespace:       "",
+				APIGroup:        "",
+				APIVersion:      "",
+				Resource:        "",
+				Subresource:     "",
+				Name:            "",
+				ResourceRequest: false,
+				Path:            "/api/v1/namespaces/templated/pods/some-pod/metrics",
+			},
+			output: expectedAttributes("get", []string{"kube-system", "default"}),
+		},
+	}
+
+	for _, tc := range testCase {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = rewrite.WithKubeRBACProxyParams(ctx, tc.params)
+			attrGen := rewrite.NewTemplatedResourceAttributesGenerator(templateResource)
+			results := attrGen.Generate(ctx, tc.input)
+			if len(results) != len(tc.params) {
+				t.Errorf(
+					"Expected %d generated attributes, but have %d",
+					len(tc.params), len(results),
+				)
+			}
+		})
+	}
+}

--- a/pkg/authorization/rewrite/config.go
+++ b/pkg/authorization/rewrite/config.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2023 the kube-rbac-proxy maintainers. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package rewrite
+
+type rewriterParamsKey int
+
+const (
+	rewriterParams rewriterParamsKey = iota
+)
+
+// RewriteAttributesConfig describes how a request's attributes should be
+// rewritten to receive a proper SubjectAccessReview.
+type RewriteAttributesConfig struct {
+	Rewrites           *SubjectAccessReviewRewrites `json:"rewrites,omitempty"`
+	ResourceAttributes *ResourceAttributes          `json:"resourceAttributes,omitempty"`
+}
+
+// SubjectAccessReviewRewrites describes how SubjectAccessReview may be
+// rewritten on a given request.
+type SubjectAccessReviewRewrites struct {
+	ByQueryParameter *QueryParameterRewriteConfig `json:"byQueryParameter,omitempty"`
+	ByHTTPHeader     *HTTPHeaderRewriteConfig     `json:"byHttpHeader,omitempty"`
+}
+
+// QueryParameterRewriteConfig describes which HTTP URL query parameter is to
+// be used to rewrite a SubjectAccessReview on a given request.
+type QueryParameterRewriteConfig struct {
+	Name string `json:"name,omitempty"`
+}
+
+// HTTPHeaderRewriteConfig describes which HTTP header is to
+// be used to rewrite a SubjectAccessReview on a given request.
+type HTTPHeaderRewriteConfig struct {
+	Name string `json:"name,omitempty"`
+}
+
+// ResourceAttributes describes attributes available for resource request authorization
+type ResourceAttributes struct {
+	Namespace   string `json:"namespace,omitempty"`
+	APIGroup    string `json:"apiGroup,omitempty"`
+	APIVersion  string `json:"apiVersion,omitempty"`
+	Resource    string `json:"resource,omitempty"`
+	Subresource string `json:"subresource,omitempty"`
+	Name        string `json:"name,omitempty"`
+}

--- a/pkg/authorization/rewrite/middleware.go
+++ b/pkg/authorization/rewrite/middleware.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2023 the kube-rbac-proxy maintainers. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package rewrite
+
+import (
+	"context"
+	"net/http"
+	"net/textproto"
+
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+// WithKubeRBACProxyParamsHandler returns a handler that adds the params from
+// the request to the context from pre-defined locations.
+// They can origin from the query parameters or from the HTTP headers.
+func WithKubeRBACProxyParamsHandler(handler http.Handler, config *RewriteAttributesConfig) http.Handler {
+	if config == nil || config.Rewrites == nil {
+		return handler
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r = r.WithContext(WithKubeRBACProxyParams(
+			r.Context(),
+			requestToParams(config, r),
+		))
+
+		handler.ServeHTTP(w, r)
+	})
+}
+
+// requestToParams returns the params from the request that should be used to
+// rewrite the attributes.
+func requestToParams(config *RewriteAttributesConfig, req *http.Request) []string {
+	params := []string{}
+
+	if config.Rewrites.ByQueryParameter != nil && config.Rewrites.ByQueryParameter.Name != "" {
+		if ps, ok := req.URL.Query()[config.Rewrites.ByQueryParameter.Name]; ok {
+			params = append(params, ps...)
+		}
+	}
+	if config.Rewrites.ByHTTPHeader != nil && config.Rewrites.ByHTTPHeader.Name != "" {
+		mimeHeader := textproto.MIMEHeader(req.Header)
+		mimeKey := textproto.CanonicalMIMEHeaderKey(config.Rewrites.ByHTTPHeader.Name)
+		if ps, ok := mimeHeader[mimeKey]; ok {
+			params = append(params, ps...)
+		}
+	}
+	return params
+}
+
+// WithKubeRBACProxyParams adds the values from the pre-defined location to the
+// context.
+func WithKubeRBACProxyParams(ctx context.Context, params []string) context.Context {
+	if len(params) == 0 {
+		return ctx
+	}
+
+	return request.WithValue(ctx, rewriterParams, params)
+}
+
+// getKubeRBACProxyParams returns the values from the context that should be
+// used to rewrite the attributes.
+func getKubeRBACProxyParams(ctx context.Context) []string {
+	params, _ := ctx.Value(rewriterParams).([]string)
+
+	return params
+}

--- a/pkg/authorization/rewrite/middleware_test.go
+++ b/pkg/authorization/rewrite/middleware_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2023 the kube-rbac-proxy maintainers. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package rewrite
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func TestRewriteParamsMiddleware(t *testing.T) {
+	testCases := []struct {
+		name     string
+		rewrite  *SubjectAccessReviewRewrites
+		request  *http.Request
+		expected []string
+	}{
+		{
+			name: "with query param rewrites config",
+			rewrite: &SubjectAccessReviewRewrites{
+				ByQueryParameter: &QueryParameterRewriteConfig{
+					Name: "namespace",
+				},
+			},
+			request: createRequest(withQueryParameters(map[string][]string{
+				"namespace": {"default"},
+			})),
+			expected: []string{"default"},
+		},
+		{
+			name: "with query param rewrites config but missing URL query",
+			rewrite: &SubjectAccessReviewRewrites{
+				ByQueryParameter: &QueryParameterRewriteConfig{
+					Name: "namespace",
+				},
+			},
+			request:  createRequest(),
+			expected: nil,
+		},
+		{
+			name: "with http header rewrites config",
+			rewrite: &SubjectAccessReviewRewrites{
+				ByHTTPHeader: &HTTPHeaderRewriteConfig{Name: "namespace"},
+			},
+			request: createRequest(withHeaderParameters(map[string][]string{
+				"namespace": {"default"},
+			})),
+			expected: []string{"default"},
+		},
+		{
+			name: "with http header rewrites config and additional header",
+			rewrite: &SubjectAccessReviewRewrites{
+				ByHTTPHeader: &HTTPHeaderRewriteConfig{Name: "namespace"},
+			},
+			request: createRequest(withHeaderParameters(map[string][]string{
+				"namespace": {"default", "other"},
+			})),
+			expected: []string{"default", "other"},
+		},
+		{
+			name: "with http header rewrites config but missing header",
+			rewrite: &SubjectAccessReviewRewrites{
+				ByQueryParameter: &QueryParameterRewriteConfig{Name: "namespace"},
+			},
+			request:  createRequest(),
+			expected: nil,
+		},
+		{
+			name: "with http header and query param rewrites config",
+			rewrite: &SubjectAccessReviewRewrites{
+				ByHTTPHeader:     &HTTPHeaderRewriteConfig{Name: "namespace"},
+				ByQueryParameter: &QueryParameterRewriteConfig{Name: "namespace"},
+			},
+			request: createRequest(
+				withHeaderParameters(map[string][]string{"namespace": {"default"}}),
+				withQueryParameters(map[string][]string{"namespace": {"kube-system"}}),
+			),
+			expected: []string{"kube-system", "default"},
+		},
+		{
+			name: "with query header rewrites config but header params",
+			rewrite: &SubjectAccessReviewRewrites{
+				ByQueryParameter: &QueryParameterRewriteConfig{Name: "namespace"},
+			},
+			request: createRequest(withHeaderParameters(map[string][]string{
+				"namespace": {"default", "other"},
+			})),
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			WithKubeRBACProxyParamsHandler(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					values := getKubeRBACProxyParams(r.Context())
+					if !reflect.DeepEqual(values, tc.expected) {
+						t.Errorf("expected values to be %v, have %v", tc.expected, values)
+					}
+				}),
+				&RewriteAttributesConfig{Rewrites: tc.rewrite},
+			).ServeHTTP(nil, tc.request)
+		})
+	}
+}
+
+type requestOptions func(*http.Request)
+
+func withQueryParameters(params map[string][]string) requestOptions {
+	return func(r *http.Request) {
+		q := r.URL.Query()
+		for key, values := range params {
+			for _, value := range values {
+				q.Add(key, value)
+			}
+		}
+		r.URL, _ = url.Parse(r.URL.String())
+		r.URL.RawQuery = q.Encode()
+	}
+}
+
+func withHeaderParameters(params map[string][]string) requestOptions {
+	return func(r *http.Request) {
+		for key, values := range params {
+			for _, value := range values {
+				r.Header.Add(key, value)
+			}
+		}
+	}
+}
+
+func createRequest(opts ...requestOptions) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/accounts", nil)
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	return r
+}

--- a/pkg/authorization/rewrite/rewrite.go
+++ b/pkg/authorization/rewrite/rewrite.go
@@ -17,75 +17,31 @@ limitations under the License.
 package rewrite
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"net/http"
-	"net/textproto"
-	"text/template"
 
 	"k8s.io/apiserver/pkg/authorization/authorizer"
-	"k8s.io/apiserver/pkg/endpoints/request"
 )
 
-var _ authorizer.Authorizer = &rewritingAuthorizer{}
-
-const rewriterParams = iota
-
-type RewriteAttributesConfig struct {
-	Rewrites           *SubjectAccessReviewRewrites `json:"rewrites,omitempty"`
-	ResourceAttributes *ResourceAttributes          `json:"resourceAttributes,omitempty"`
-}
-
-// SubjectAccessReviewRewrites describes how SubjectAccessReview may be
-// rewritten on a given request.
-type SubjectAccessReviewRewrites struct {
-	ByQueryParameter *QueryParameterRewriteConfig `json:"byQueryParameter,omitempty"`
-	ByHTTPHeader     *HTTPHeaderRewriteConfig     `json:"byHttpHeader,omitempty"`
-}
-
-// QueryParameterRewriteConfig describes which HTTP URL query parameter is to
-// be used to rewrite a SubjectAccessReview on a given request.
-type QueryParameterRewriteConfig struct {
-	Name string `json:"name,omitempty"`
-}
-
-// HTTPHeaderRewriteConfig describes which HTTP header is to
-// be used to rewrite a SubjectAccessReview on a given request.
-type HTTPHeaderRewriteConfig struct {
-	Name string `json:"name,omitempty"`
-}
-
-// ResourceAttributes describes attributes available for resource request authorization
-type ResourceAttributes struct {
-	Namespace   string `json:"namespace,omitempty"`
-	APIGroup    string `json:"apiGroup,omitempty"`
-	APIVersion  string `json:"apiVersion,omitempty"`
-	Resource    string `json:"resource,omitempty"`
-	Subresource string `json:"subresource,omitempty"`
-	Name        string `json:"name,omitempty"`
-}
-
-func NewRewritingAuthorizer(delegate authorizer.Authorizer, config *RewriteAttributesConfig) *rewritingAuthorizer {
-	rewriteConfig := config
-	if rewriteConfig == nil {
-		rewriteConfig = &RewriteAttributesConfig{}
-	}
-
+func NewRewritingAuthorizer(delegate authorizer.Authorizer, attrsGenerator AttributesGenerator) authorizer.Authorizer {
 	return &rewritingAuthorizer{
-		config:   rewriteConfig,
-		delegate: delegate,
+		delegate:            delegate,
+		attributesGenerator: attrsGenerator,
 	}
 }
 
 type rewritingAuthorizer struct {
-	config   *RewriteAttributesConfig
-	delegate authorizer.Authorizer
+	delegate            authorizer.Authorizer
+	attributesGenerator AttributesGenerator
 }
 
-// GetRequestAttributes populates authorizer attributes for the requests to kube-rbac-proxy.
+var _ authorizer.Authorizer = &rewritingAuthorizer{}
+
+// Authorize generates a list of attributes based on the given attributes generator
+// and context. All attributes must be authorized to allow the request.
+// If no attributes are generated, the request is denied.
 func (n *rewritingAuthorizer) Authorize(ctx context.Context, attrs authorizer.Attributes) (authorizer.Decision, string, error) {
-	proxyAttrs := n.getKubeRBACProxyAuthzAttributes(ctx, attrs)
+	proxyAttrs := n.attributesGenerator.Generate(ctx, attrs)
 
 	if len(proxyAttrs) == 0 {
 		return authorizer.DecisionDeny,
@@ -98,6 +54,8 @@ func (n *rewritingAuthorizer) Authorize(ctx context.Context, attrs authorizer.At
 		reason     string
 		err        error
 	)
+
+	// AND logic on all SubjectAccessReview requests.
 	for _, at := range proxyAttrs {
 		authorized, reason, err = n.delegate.Authorize(ctx, at)
 		if err != nil {
@@ -113,116 +71,11 @@ func (n *rewritingAuthorizer) Authorize(ctx context.Context, attrs authorizer.At
 	}
 
 	if authorized == authorizer.DecisionAllow {
-		return authorized, "", nil
+		return authorizer.DecisionAllow, "", nil
 	}
 
+	// Most probably never happens.
 	return authorizer.DecisionDeny,
 		"No attribute combination matched",
 		nil
-}
-
-func (n *rewritingAuthorizer) getKubeRBACProxyAuthzAttributes(ctx context.Context, origAttrs authorizer.Attributes) []authorizer.Attributes {
-	u := origAttrs.GetUser()
-	apiVerb := origAttrs.GetVerb()
-	path := origAttrs.GetPath()
-
-	attrs := []authorizer.Attributes{}
-	if n.config.ResourceAttributes == nil {
-		// Default attributes mirror the API attributes that would allow this access to kube-rbac-proxy
-		return append(attrs,
-			authorizer.AttributesRecord{
-				User:            u,
-				Verb:            apiVerb,
-				ResourceRequest: false,
-				Path:            path,
-			})
-	}
-
-	if n.config.Rewrites == nil {
-		return append(attrs,
-			authorizer.AttributesRecord{
-				User:            u,
-				Verb:            apiVerb,
-				Namespace:       n.config.ResourceAttributes.Namespace,
-				APIGroup:        n.config.ResourceAttributes.APIGroup,
-				APIVersion:      n.config.ResourceAttributes.APIVersion,
-				Resource:        n.config.ResourceAttributes.Resource,
-				Subresource:     n.config.ResourceAttributes.Subresource,
-				Name:            n.config.ResourceAttributes.Name,
-				ResourceRequest: true,
-			})
-
-	}
-
-	params := GetKubeRBACProxyParams(ctx)
-	if len(params) == 0 {
-		return nil
-	}
-
-	for _, param := range params {
-		attrs = append(attrs,
-			authorizer.AttributesRecord{
-				User:            u,
-				Verb:            apiVerb,
-				Namespace:       templateWithValue(n.config.ResourceAttributes.Namespace, param),
-				APIGroup:        templateWithValue(n.config.ResourceAttributes.APIGroup, param),
-				APIVersion:      templateWithValue(n.config.ResourceAttributes.APIVersion, param),
-				Resource:        templateWithValue(n.config.ResourceAttributes.Resource, param),
-				Subresource:     templateWithValue(n.config.ResourceAttributes.Subresource, param),
-				Name:            templateWithValue(n.config.ResourceAttributes.Name, param),
-				ResourceRequest: true,
-			})
-	}
-
-	return attrs
-}
-
-func templateWithValue(templateString, value string) string {
-	tmpl, _ := template.New("valueTemplate").Parse(templateString)
-	out := bytes.NewBuffer(nil)
-	err := tmpl.Execute(out, struct{ Value string }{Value: value})
-	if err != nil {
-		return ""
-	}
-	return out.String()
-}
-
-func WithKubeRBACProxyParamsHandler(handler http.Handler, config *RewriteAttributesConfig) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r = r.WithContext(WithKubeRBACProxyParams(r.Context(), requestToParams(config, r)))
-		handler.ServeHTTP(w, r)
-	})
-}
-
-func requestToParams(config *RewriteAttributesConfig, req *http.Request) []string {
-	params := []string{}
-	if config == nil || config.Rewrites == nil {
-		return nil
-	}
-
-	if config.Rewrites.ByQueryParameter != nil && config.Rewrites.ByQueryParameter.Name != "" {
-		if ps, ok := req.URL.Query()[config.Rewrites.ByQueryParameter.Name]; ok {
-			params = append(params, ps...)
-		}
-	}
-	if config.Rewrites.ByHTTPHeader != nil && config.Rewrites.ByHTTPHeader.Name != "" {
-		mimeHeader := textproto.MIMEHeader(req.Header)
-		mimeKey := textproto.CanonicalMIMEHeaderKey(config.Rewrites.ByHTTPHeader.Name)
-		if ps, ok := mimeHeader[mimeKey]; ok {
-			params = append(params, ps...)
-		}
-	}
-	return params
-}
-
-func WithKubeRBACProxyParams(ctx context.Context, params []string) context.Context {
-	return request.WithValue(ctx, rewriterParams, params)
-}
-
-func GetKubeRBACProxyParams(ctx context.Context) []string {
-	params, ok := ctx.Value(rewriterParams).([]string)
-	if !ok {
-		return nil
-	}
-	return params
 }


### PR DESCRIPTION
# What

- Re-order authz-validation-logic to match previous (correct) order.
- Split attributes rewrite from authorizer.Authorizer logic.
- Don't load all variations, even though config picks one.
- Minor improvements from @enj's review.

# Why

- The authorization logic is messy.
- Templates are parse per request.
- All authorizers are loaded, even though only one is picked.