### PR TITLE
p/a/path: fail on broken pattern early, add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ To get kube-rbac-proxy accepted as an official Kubernetes SIG Auth repository, w
 - `--insecure-listen-addres` - the proxy is handling authentication information and will no longer run in an unsafe mode
 - `--auth-header-fields-enabled` - its value is derived from at least one of `--auth-header-groups-field-name` or `--auth-header-user-field-name` being set
 - `--tls-reload-interval` - upstream Kubernetes TLS material is now being reloaded by Kubernetes upstream code which chooses its own reasonable defaults
+- **infix regex** for `--allow-paths` and `--ignore-paths` - the proxy now uses postfix matching with `*` as its sole wildcard operator, instead of infix matching with different wildcard operators:
+  - `/api/v1/*` matches now `/api/v1`, `/api/v1/foo` and `/api/v1/foo/bar`, **previously** it didn't match `/api/v1/foo/bar`.
+  - `/api/v1/*/values` creates an error on server startup, **previously** it matched `/api/v1/foo/values` and `/api/v1/bar/values`.
+  - details: [Allow Path and Ignore Path changes](docs/path.md)
 
 #### Replaced:
 - `--kubeconfig` - use `--authentication-kubeconfig` and `--authorization-kubeconfig` instead

--- a/docs/migration/path.md
+++ b/docs/migration/path.md
@@ -1,0 +1,44 @@
+# Allow Path and Ignore Path
+
+## Description
+
+If `--allow-paths` is set, only the requests to these paths will be considered for proxying, the rest will be rejected.
+If `--ignore-paths` is set, requests to these paths will be passed upstream without any authorization.
+
+Only one of `--allow-paths`/`--ignore-paths` is allowed to be set at a time.
+
+## Change
+
+Previously, it was possible to configure an **infix wildcard** but that will now fail.
+Now **infix regex** will cause an error on server startup.
+kube-rbac-proxy won't start with an **infix regex**.
+E.g. `--allow-path="/api/v1/*/values"` will cause kube-rbac-proxy fail to start.
+E.g. `--ignore-path="/api/v1/*/values"` will cause kube-rbac-proxy fail to start.
+
+Previously `*` would count as a single-path-segment wildcard ([path.Match](https://pkg.go.dev/path#Match)).
+Now the wildcard is matching any string, even if it contains `/`.
+E.g. `--allow-path="/api/v1/*"` would have rejected `/api/v1/label/values`, with the change it is being evaluated.
+E.g. `--ignore-path="/api/v1/*"` would have evaluated `/api/v1/label/values`, with the change it is being passed through. 
+
+### Reason
+
+We are in an effort to mirate kube-rbac-proxy to the k8s sig-auth organization.
+In order to meet the requirements of the k8s sig-auth organization we need to adjust the code base.
+The kubernetes code base doesn't allow **infix regex**.
+It is considered a security risk in case of misconfiguration.
+
+## Call to action
+
+You need to act if you:
+
+### Use infix wildcard operator
+
+If `/api/v1/*/values` was used and `/api/v1/labels` shouldn't match `/api/v1/*`, it needs to be replaced with every individual path segment.
+
+### Expect wildcard operator to match exactly one path sagment
+
+If `/api/v1/*` shouldn't match `/api/v1/label/values` but `/api/v1/label` it is necessary to replace the wildcard operator with every individual path sagment.
+
+### Use other wildcard operators than `*`, like `?`
+
+If `/api/v1/label*` shouldn't match `/api/v1/labels/values` but `/api/v1/labels` it is necessary to replace the wildcard operator with every individual path sagment.

--- a/test/e2e/allowpaths/deployment.yaml
+++ b/test/e2e/allowpaths/deployment.yaml
@@ -21,7 +21,7 @@ spec:
             - "--secure-port=8443"
             - "--proxy-endpoints-port=8643"
             - "--upstream=http://127.0.0.1:8081/"
-            - "--allow-paths=/metrics,/api/v1/label/*/values"
+            - "--allow-paths=/metrics,/api/v1/label/*"
             - "--authentication-skip-lookup"
             - "--logtostderr=true"
             - "--v=10"

--- a/test/e2e/basics.go
+++ b/test/e2e/basics.go
@@ -358,7 +358,7 @@ func testAllowPathsRegexp(client kubernetes.Interface) kubetest.TestSuite {
 				),
 				kubetest.ClientSucceeds(
 					client,
-					fmt.Sprintf(command, "/api/v1/label/name", 403, 403),
+					fmt.Sprintf(command, "/api/v1", 403, 403),
 					nil,
 				),
 			),
@@ -452,7 +452,17 @@ func testIgnorePaths(client kubernetes.Interface) kubetest.TestSuite {
 				),
 				kubetest.ClientSucceeds(
 					client,
+					fmt.Sprintf(commandWithoutAuth, "/api/v1/", 200, 200),
+					nil,
+				),
+				kubetest.ClientSucceeds(
+					client,
 					fmt.Sprintf(commandWithoutAuth, "/api/v1/labels", 200, 200),
+					nil,
+				),
+				kubetest.ClientSucceeds(
+					client,
+					fmt.Sprintf(commandWithoutAuth, "/api/v1/label/values", 200, 200),
 					nil,
 				),
 			),
@@ -497,7 +507,12 @@ func testIgnorePaths(client kubernetes.Interface) kubetest.TestSuite {
 				),
 				kubetest.ClientSucceeds(
 					client,
-					fmt.Sprintf(commandWithoutAuth, "/api/v1/label/job/values", 403, 403),
+					fmt.Sprintf(commandWithoutAuth, "/api/v1", 403, 403),
+					nil,
+				),
+				kubetest.ClientSucceeds(
+					client,
+					fmt.Sprintf(commandWithoutAuth, "/api/v12", 403, 403),
 					nil,
 				),
 			),


### PR DESCRIPTION
# What

- Change path-authorizer to act like upstream (only postfix patterns).
- Fail on broken pattern.
- Add unit tests for Ignore-Path-Case

# Why

- Upstream doesn't use complex patter matching from the standard library. It is prone to misconfiguration.
- If a broken pattern is given, it behaved like a pattern match.
- There were no unit tests for the Ignore-Path-Case.
