### PR TITLE
Makefile: revert VERSION, add VERSION_SEMVER

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
         go-version: ${{ env.go-version }}
     - name: Create container & run tests
       run: |
-        DOCKER_TAG=local make container
+        VERSION=local VERSION_SEMVER=$(cat ./VERSION) make container
         kind load docker-image ${QUAY_PATH}:local
         until docker exec $(kind get nodes) crictl images | grep "${QUAY_PATH}"; do
           echo "no kube-rbac-proxy image"


### PR DESCRIPTION
# What

Revert VERSION variable change and introduce VERSION_SEMVER, which is a SEMVER version of VERSION.

# Why

- Fixes `scripts/publish.sh`
- VERSION is way to complicated to "simply change".
- Solves https://github.com/brancz/kube-rbac-proxy/issues/255

# Notes

It is way easier to read, when you compare it against `v0.14.2`, rather than `v0.14.3`.