### PR TITLE
Fallback to the trusted host ca bundle in the oidc case

### DIFF
--- a/pkg/authn/oidc.go
+++ b/pkg/authn/oidc.go
@@ -31,12 +31,20 @@ type OIDCAuthenticator struct {
 	requestAuthenticator authenticator.Request
 }
 
+const (
+	trustedHostCABundle = "/etc/ssl/certs/ca-certificates.crt"
+)
+
 var (
 	_ (authenticator.Request) = (*OIDCAuthenticator)(nil)
 )
 
 // NewOIDCAuthenticator returns OIDC authenticator
 func NewOIDCAuthenticator(config *OIDCConfig) (*OIDCAuthenticator, error) {
+	if config.CAFile == "" {
+		//If the CA file is empty, it shall default to the host system trusted ca bundle
+		config.CAFile = trustedHostCABundle
+	}
 	dyCA, err := dynamiccertificates.NewDynamicCAContentFromFile("oidc-ca", config.CAFile)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# What

Attempt to use the trusted system ca bundle in the when such is not provided, following the description of the `--oidc-ca-file` configuration parameter.

# Why

Current behavior emits an error when `--oidc-ca-file` is not provided. Fixes #259
