### PR TITLE
deps: patch cve-2023-45142, not affecting krp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -105,4 +105,5 @@ require (
 replace (
 	github.com/emicklei/go-restful/v3 => github.com/emicklei/go-restful/v3 v3.11.0
 	go.etcd.io/etcd/client/v3 => go.etcd.io/etcd/client/v3 v3.5.9 // indirect
+	go.opentelemetry.io/contrib/instrumentation => go.opentelemetry.io/contrib/instrumentation v0.44.0
 )


### PR DESCRIPTION
# What

bump opentelemetry.

# Why

dumb security scanners go mad.