### PR TITLE
Allow BASEIMAGE to be overriden at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG GOARCH=amd64
 ARG GOOS=linux
-FROM gcr.io/distroless/static:nonroot-$GOARCH
+ARG BASEIMAGE=gcr.io/distroless/static:nonroot-$GOARCH
+FROM $BASEIMAGE
 
 ARG BINARY=kube-rbac-proxy-$GOOS-$GOARCH
 COPY _output/$BINARY /usr/local/bin/kube-rbac-proxy

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ PROGRAM_NAME?=kube-rbac-proxy
 GITHUB_URL=github.com/brancz/kube-rbac-proxy
 GOOS?=$(shell uname -s | tr A-Z a-z)
 GOARCH?=$(shell go env GOARCH)
+BASEIMAGE?=gcr.io/distroless/static:nonroot-$(GOARCH)
 OUT_DIR=_output
 VERSION?=$(shell cat VERSION)-$(shell git rev-parse --short HEAD)
 VERSION_SEMVER?=$(shell echo $(VERSION) | grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+')
@@ -56,7 +57,7 @@ update-go-deps:
 	go mod tidy
 
 container: $(OUT_DIR)/$(PROGRAM_NAME)-$(GOOS)-$(GOARCH) Dockerfile
-	docker build --build-arg BINARY=$(PROGRAM_NAME)-$(GOOS)-$(GOARCH) --build-arg GOARCH=$(GOARCH) -t $(CONTAINER_NAME)-$(GOARCH) .
+	docker build --build-arg BINARY=$(PROGRAM_NAME)-$(GOOS)-$(GOARCH) --build-arg GOARCH=$(GOARCH) --build-arg BASEIMAGE=$(BASEIMAGE) -t $(CONTAINER_NAME)-$(GOARCH) .
 ifeq ($(GOARCH), amd64)
 	docker tag $(DOCKER_REPO):$(VERSION)-$(GOARCH) $(CONTAINER_NAME)
 endif


### PR DESCRIPTION
Right now the Dockerfile uses `gcr.io/distroless/static:nonroot-$GOARCH`, this change just allows us to override the BASEIMAGE file similar to GOARCH / GOOS when using `make`.

I tested a few variations, like this:

```
$ make container

$ DOCKER_REPO=gcr.io/wpanther-gke-dev/kube-rbac-proxy make container

$ DOCKER_REPO=gcr.io/wpanther-gke-dev/kube-rbac-proxy BASEIMAGE=debian:bookworm make container
```

All of them built correctly. I extracted the resulting image from the last one to verify it was updated properly, here's the `PRETTY_NAME` in `etc/os-release`:

```
$ cat ./layer/etc/os-release | grep PRETTY
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
```

Edit: to add some context, I'd like to be able to build `kube-rbac-proxy` with a base image / digest in my own CI/CD for reproducibility. I thought this might be a good way to provide flexibility without changing any existing workflows.