### PR TITLE
add command line args --kube-api-qps/--kube-api-burst

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Kube-rbac-proxy flags:
       --http2-max-size uint32                       The maximum number of bytes that the server will accept for frame size and buffer per stream in a HTTP/2 request. (default 262144)
       --ignore-paths strings                        Comma-separated list of paths against which kube-rbac-proxy pattern-matches the incoming request. If the requst matches, it will proxy the request without performing an authentication or authorization check. Cannot be used with --allow-paths.
       --insecure-listen-address string              [DEPRECATED] The address the kube-rbac-proxy HTTP server should listen on.
+      --kube-api-burst int                          kube-api burst value; needed when kube-api-qps is set
+      --kube-api-qps float32                        queries per second to the api, kube-client starts client-side throttling, when breached
       --kubeconfig string                           Path to a kubeconfig file, specifying how to connect to the API server. If unset, in-cluster configuration will be used
       --oidc-ca-file string                         If set, the OpenID server's certificate will be verified by one of the authorities in the oidc-ca-file, otherwise the host's root CA set will be used.
       --oidc-clientID string                        The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.

--- a/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
+++ b/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
@@ -189,6 +189,13 @@ func Complete(o *options.ProxyRunOptions) (*completedProxyRunOptions, error) {
 		return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
 	}
 
+	if o.QPS > 0 {
+	    kubeconfig.QPS = o.QPS
+	}
+	if o.Burst > 0 {
+	    kubeconfig.Burst = o.Burst
+	}
+
 	completed.kubeClient, err = kubernetes.NewForConfig(kubeconfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to instantiate Kubernetes client: %w", err)

--- a/cmd/kube-rbac-proxy/app/options/options.go
+++ b/cmd/kube-rbac-proxy/app/options/options.go
@@ -51,6 +51,9 @@ type ProxyRunOptions struct {
 	HTTP2MaxConcurrentStreams uint32
 	HTTP2MaxSize              uint32
 
+	QPS   float32
+	Burst int
+
 	flagSet *pflag.FlagSet
 }
 
@@ -137,6 +140,8 @@ func (o *ProxyRunOptions) Flags() k8sapiflag.NamedFlagSets {
 
 	//Kubeconfig flag
 	flagset.StringVar(&o.KubeconfigLocation, "kubeconfig", "", "Path to a kubeconfig file, specifying how to connect to the API server. If unset, in-cluster configuration will be used")
+	flagset.Float32Var(&o.QPS, "kube-api-qps", 0, "queries per second to the api, kube-client starts client-side throttling, when breached")
+	flagset.IntVar(&o.Burst, "kube-api-burst", 0, "kube-api burst value; needed when kube-api-qps is set")
 
 	// HTTP2 flags
 	flagset.BoolVar(&o.HTTP2Disable, "http2-disable", false, "Disable HTTP/2 support")


### PR DESCRIPTION
Using kube-rbac-proxy in front of a prometheus in a multi tenant environment causes often client-side throttling events, that slow down connections, when more than 10 queries per second  are coming in. Only way to mitigate is to increase the number of replicas of the kube-rbac-proxy pods.

**Example for client-side throttling**:
I0318 12:32:18.188838     800 request.go:629] Waited for 993.646183ms due to client-side throttling, not priority and fairness, request: POST:https://172.30.0.1:443/apis/authorization.k8s.io/v1/subjectaccessreviews
I0318 12:32:18.192938     800 round_trippers.go:553] POST https://172.30.0.1:443/apis/authorization.k8s.io/v1/subjectaccessreviews 201 Created in 3 milliseconds
I0318 12:32:19.189607     800 request.go:629] Waited for 1.994365552s due to client-side throttling, not priority and fairness, request: POST:https://172.30.0.1:443/apis/authorization.k8s.io/v1/subjectaccessreviews

with the new parameters, the queries per second can be set above the default kube-client default value of 10 qps.
--kube-api-qps
--kube-api-burst 
