### PR TITLE
 fix bool,deprecated flags regression

### DIFF
--- a/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
+++ b/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
@@ -190,10 +190,10 @@ func Complete(o *options.ProxyRunOptions) (*completedProxyRunOptions, error) {
 	}
 
 	if o.QPS > 0 {
-	    kubeconfig.QPS = o.QPS
+		kubeconfig.QPS = o.QPS
 	}
 	if o.Burst > 0 {
-	    kubeconfig.Burst = o.Burst
+		kubeconfig.Burst = o.Burst
 	}
 
 	completed.kubeClient, err = kubernetes.NewForConfig(kubeconfig)
@@ -490,6 +490,10 @@ func Run(cfg *completedProxyRunOptions) error {
 		}, func(err error) {
 			close(sig)
 		})
+	}
+
+	if len(cfg.secureListenAddress) == 0 && len(cfg.insecureListenAddress) == 0 {
+		return fmt.Errorf("no listen address provided")
 	}
 
 	if err := gr.Run(); err != nil {

--- a/cmd/kube-rbac-proxy/app/options/deprecated.go
+++ b/cmd/kube-rbac-proxy/app/options/deprecated.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2024 the kube-rbac-proxy maintainers. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+	"k8s.io/klog/v2"
+)
+
+var disabledFlagsType = map[string]string{
+	"logtostderr":       "bool",
+	"add-dir-header":    "bool",
+	"alsologtostderr":   "bool",
+	"log-backtrace-at":  "string",
+	"log-dir":           "string",
+	"log-file":          "string",
+	"log-file-max-size": "uint64",
+	"one-output":        "bool",
+	"skip-headers":      "bool",
+	"skip-log-headers":  "bool",
+	"stderrthreshold":   "string",
+}
+
+func (o *ProxyRunOptions) addDisabledFlags(flagset *pflag.FlagSet) {
+	// disabled flags
+	o.flagSet = flagset // reference used for validation
+
+	for name, typeStr := range disabledFlagsType {
+		switch typeStr {
+		case "bool":
+			_ = flagset.Bool(name, false, "[DISABLED]")
+		case "string":
+			_ = flagset.String(name, "", "[DISABLED]")
+		case "uint64":
+			_ = flagset.Uint64(name, 0, "[DISABLED]")
+		default:
+			panic(fmt.Sprintf("unknown type %q", typeStr))
+		}
+
+		if err := flagset.MarkHidden(name); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func (o *ProxyRunOptions) validateDisabledFlags() error {
+	// Removed upstream flags shouldn't be use
+	for disabledOpt := range disabledFlagsType {
+		if flag := o.flagSet.Lookup(disabledOpt); flag.Changed {
+			klog.Warningf(`
+==== Removed Flag Warning ======================
+
+%s is removed in the k8s upstream and has no effect any more.
+
+===============================================
+		`, disabledOpt)
+		}
+	}
+
+	return nil
+}

--- a/test/e2e/flags/deployment-logtostderr.yaml
+++ b/test/e2e/flags/deployment-logtostderr.yaml
@@ -19,8 +19,8 @@ spec:
           image: quay.io/brancz/kube-rbac-proxy:local
           args:
             - "--secure-listen-address=0.0.0.0:8443"
+            - "--logtostderr"
             - "--upstream=http://127.0.0.1:8081/"
-            - "--logtostderr=true"
             - "--v=10"
           ports:
             - containerPort: 8443


### PR DESCRIPTION
## What

Fix a regression for the removed flags.

## Why

If the bool value flag was specified like `--logtostderr`, without the `=true`, it was treated like `--logtostderr=true` in v0.15.0.
In v0.16.0 and v0.17.0, `--logtostderr` without any value would treat the follow up flag as its value, which leads to a regression.