### PR TITLE
Implement method not allowed response

### DIFF
--- a/pkg/filters/auth.go
+++ b/pkg/filters/auth.go
@@ -95,7 +95,11 @@ func WithAuthorization(
 			if authorized != authorizer.DecisionAllow {
 				msg := fmt.Sprintf("Forbidden (user=%s, verb=%s, resource=%s, subresource=%s)", u.GetName(), attrs.GetVerb(), attrs.GetResource(), attrs.GetSubresource())
 				klog.V(2).Infof("%s. Reason: %q.", msg, reason)
-				http.Error(w, msg, http.StatusForbidden)
+				if authorized == authorizer.DecisionDeny {
+					http.Error(w, msg, http.StatusMethodNotAllowed)
+				} else {
+					http.Error(w, msg, http.StatusForbidden)
+				}
 				return
 			}
 		}


### PR DESCRIPTION
Currently, auth return a `403` error whenever the user have other access or not.

This PR suggest to add `405` status code when authorization config contains another verb than the one needed.

This will allow usage of golang prometheus client that actually send a `POST` query first before retrying on a `GET` one if the response code is `405 = StatusMethodNotAllowed`
https://github.com/prometheus/client_golang/blob/main/api/prometheus/v1/api.go#L1436-L1462