### PR TITLE
improve proxy healthz checking

### DIFF
--- a/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
+++ b/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
@@ -249,6 +249,7 @@ func Run(cfg *server.KubeRBACProxyConfig) error {
 		return err
 	}
 
+	var stoppedCh, listenerStoppedCh <-chan struct{}
 	go func() {
 		defer wg.Done()
 		defer cancel()
@@ -263,11 +264,15 @@ func Run(cfg *server.KubeRBACProxyConfig) error {
 		<-stoppedCh
 	}()
 
+	cfg.SecureServing.Cert.CurrentCertKeyContent()
+
 	if cfg.KubeRBACProxyInfo.ProxyEndpointsSecureServing != nil {
 		// we need a second listener in order to serve proxy-specific endpoints
 		// on a different port (--proxy-endpoints-port)
 		proxyEndpointsMux := http.NewServeMux()
-		proxyEndpointsMux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("ok")) })
+		proxyEndpointsMux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+			proxyHealtzCheck(w, cfg.SecureServing.Listener.Addr().String(), listenerStoppedCh, stoppedCh)
+		})
 
 		if err := wg.Add(1); err != nil {
 			return err
@@ -353,4 +358,32 @@ func setupAuthorizer(krbInfo *server.KubeRBACProxyInfo, delegatedAuthz *serverco
 	}
 
 	return rewritingAuthorizer, nil
+}
+
+func proxyHealtzCheck(w http.ResponseWriter, localProxyAddr string, listenerStoppedChan, stoppedChan <-chan struct{}) {
+	select {
+	case <-stoppedChan:
+		http.Error(w, "the proxying port serving logic has stopped", http.StatusServiceUnavailable)
+		return
+	case <-listenerStoppedChan:
+		http.Error(w, "listener stopped", http.StatusServiceUnavailable)
+		return
+	default:
+	}
+
+	// we need the tls.Dialer otherwise the server would log EOF for TLS handshakes
+	// since the connection would be cut before that was ever attempted
+	dialer := tls.Dialer{NetDialer: &net.Dialer{}, Config: &tls.Config{InsecureSkipVerify: true}}
+	dialCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// we just knock on the other listener as we don't want to trigger proxying to upstream
+	conn, err := dialer.DialContext(dialCtx, "tcp", localProxyAddr)
+	if err != nil {
+		http.Error(w, "failed to connect to the proxying listener", http.StatusInternalServerError)
+		klog.Errorf("failed to connect to the proxying listener: %v", err)
+		return
+	}
+	_ = conn.Close()
+	_, _ = w.Write([]byte("ok"))
 }

--- a/test/e2e/basics/deployment.yaml
+++ b/test/e2e/basics/deployment.yaml
@@ -19,12 +19,20 @@ spec:
           image: quay.io/brancz/kube-rbac-proxy:local
           args:
             - "--secure-port=8443"
+            - "--proxy-endpoints-port=8643"
             - "--upstream=http://127.0.0.1:8081/"
             - "--authentication-skip-lookup"
             - "--v=10"
           ports:
             - containerPort: 8443
               name: https
+            - containerPort: 8643
+              name: proxy
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              port: 8643
+              path: healthz
         - name: prometheus-example-app
           image: quay.io/brancz/prometheus-example-app:v0.1.0
           args:

--- a/test/e2e/basics/service.yaml
+++ b/test/e2e/basics/service.yaml
@@ -10,5 +10,8 @@ spec:
     - name: https
       port: 8443
       targetPort: https
+    - name: proxy
+      port: 8643
+      targetPort: proxy
   selector:
     app: kube-rbac-proxy

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -52,6 +52,7 @@ func TestMain(m *testing.M) {
 func Test(t *testing.T) {
 	tests := map[string]kubetest.TestSuite{
 		"Basics":             testBasics(client),
+		"Healthz":            testHealthz(client),
 		"H2CUpstream":        testH2CUpstream(client),
 		"IdentityHeaders":    testIdentityHeaders(client),
 		"ClientCertificates": testClientCertificates(client),


### PR DESCRIPTION
This adds and internal conn check between the proxy-endpoints and main-proxy listener.

Fixes https://github.com/brancz/kube-rbac-proxy/issues/320