### PR TITLE
include client-go logging

### DIFF
--- a/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
+++ b/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/request"
 	serverconfig "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	k8sapiflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/cli/globalflag"
 	"k8s.io/component-base/logs"
@@ -65,12 +64,6 @@ that can perform RBAC authorization against the Kubernetes API using SubjectAcce
 
 		// stop printing usage when the command errors
 		SilenceUsage: true,
-		PersistentPreRunE: func(*cobra.Command, []string) error {
-			// silence client-go warnings.
-			// kube-apiserver loopback clients should not log self-issued warnings.
-			rest.SetDefaultWarningHandler(rest.NoWarnings{})
-			return nil
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			verflag.PrintAndExitIfRequested()
 


### PR DESCRIPTION
This was likely a copy-paste error, the clients used in KRP are not loopback apiserver clients.

Fixes https://github.com/brancz/kube-rbac-proxy/issues/317