### PR TITLE
e2e: don't pass client via globvar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ test-unit:
 	go test -v -race -count=1 $(PKGS)
 
 test-e2e:
-	go test -timeout 55m -v ./test/e2e/ $(TEST_RUN_ARGS) --kubeconfig=$(KUBECONFIG)
+	go test -timeout 55m -v ./test/e2e/ $(TEST_RUN_ARGS)
 
 test-local-setup: VERSION = local
 test-local-setup: VERSION_SEMVER = $(shell cat VERSION)


### PR DESCRIPTION
Use the kube-native way to construct a client by using the KUBECONFIG env var. That was done in the tests anyway (see the change to the Makefile).

The current system promotes using globvars which is a malpractice that should be avoided. It's only confusing new contributors. Let's remove it and just use the KUBECONFIG variable as in the rest of the Kubernetes ecosystem.