### PR TITLE
explicitly require OIDC audience for the OIDC authenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ Proxy flags:
 OIDC flags:
 
       --oidc-ca-file string           If set, the OpenID server's certificate will be verified by one of the authorities in the oidc-ca-file, otherwise the host's root CA set will be used.
-      --oidc-clientID string          The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.
       --oidc-groups-claim string      Identifier of groups in JWT claim, by default set to 'groups' (default "groups")
       --oidc-groups-prefix string     If provided, all groups will be prefixed with this value to prevent conflicts with other authentication strategies.
       --oidc-issuer string            The URL of the OpenID issuer, only HTTPS scheme will be accepted. If set, it will be used to verify the OIDC JSON Web Token (JWT).
+      --oidc-required-audience aud    The audience that must appear in all incoming tokens' aud claim. Must be set if `oidc-issuer` is configured.
       --oidc-sign-alg stringArray     Supported signing algorithms, default RS256 (default [RS256])
       --oidc-username-claim string    Identifier of the user in JWT claim, by default set to 'email' (default "email")
       --oidc-username-prefix string   If provided, the username will be prefixed with this value to prevent conflicts with other authentication strategies.

--- a/cmd/kube-rbac-proxy/app/options/oidcoptions.go
+++ b/cmd/kube-rbac-proxy/app/options/oidcoptions.go
@@ -17,6 +17,8 @@ limitations under the License.
 package options
 
 import (
+	"fmt"
+
 	"github.com/brancz/kube-rbac-proxy/pkg/authn"
 	"github.com/brancz/kube-rbac-proxy/pkg/server"
 	"github.com/spf13/pflag"
@@ -29,7 +31,7 @@ type OIDCOptions struct {
 func (o *OIDCOptions) AddFlags(flagset *pflag.FlagSet) {
 	//Authn OIDC flags
 	flagset.StringVar(&o.IssuerURL, "oidc-issuer", "", "The URL of the OpenID issuer, only HTTPS scheme will be accepted. If set, it will be used to verify the OIDC JSON Web Token (JWT).")
-	flagset.StringVar(&o.ClientID, "oidc-clientID", "", "The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set.")
+	flagset.StringVar(&o.RequiredAudience, "oidc-required-audience", "", "The audience that must appear in all incoming tokens' `aud` claim. Must be set if `oidc-issuer` is configured.")
 	flagset.StringVar(&o.UsernameClaim, "oidc-username-claim", "email", "Identifier of the user in JWT claim, by default set to 'email'")
 	flagset.StringVar(&o.GroupsClaim, "oidc-groups-claim", "groups", "Identifier of groups in JWT claim, by default set to 'groups'")
 	flagset.StringVar(&o.UsernamePrefix, "oidc-username-prefix", "", "If provided, the username will be prefixed with this value to prevent conflicts with other authentication strategies.")
@@ -41,6 +43,14 @@ func (o *OIDCOptions) AddFlags(flagset *pflag.FlagSet) {
 
 func (o *OIDCOptions) Validate() []error {
 	var errs []error
+	if len(o.IssuerURL) == 0 {
+		return errs
+	}
+
+	if len(o.RequiredAudience) == 0 {
+		errs = append(errs, fmt.Errorf("oidc-required-audience must be set when `oidc-issuer` is configured"))
+	}
+
 	return errs
 }
 

--- a/examples/oidc/deployment.yaml
+++ b/examples/oidc/deployment.yaml
@@ -72,7 +72,7 @@ spec:
         - "--upstream=http://127.0.0.1:8081/"
         - "--v=10"
         - "--oidc-issuer={ISSUER}"
-        - "--oidc-clientID={CLIENT_ID}"
+        - "--oidc-required-audience={CLIENT_ID}"
         ports:
         - containerPort: 8443
           name: https

--- a/pkg/authn/config.go
+++ b/pkg/authn/config.go
@@ -31,7 +31,7 @@ type TokenConfig struct {
 // OIDCConfig represents configuration used for JWT request authentication
 type OIDCConfig struct {
 	IssuerURL            string
-	ClientID             string
+	RequiredAudience     string
 	CAFile               string
 	UsernameClaim        string
 	UsernamePrefix       string

--- a/pkg/authn/oidc.go
+++ b/pkg/authn/oidc.go
@@ -47,7 +47,7 @@ func NewOIDCAuthenticator(ctx context.Context, config *OIDCConfig) (*OIDCAuthent
 		JWTAuthenticator: apiserver.JWTAuthenticator{
 			Issuer: apiserver.Issuer{
 				URL:       config.IssuerURL,
-				Audiences: []string{config.ClientID},
+				Audiences: []string{config.RequiredAudience},
 			},
 			ClaimMappings: apiserver.ClaimMappings{
 				Username: apiserver.PrefixedClaimOrExpression{

--- a/scripts/templates/oidc-deployment.yaml
+++ b/scripts/templates/oidc-deployment.yaml
@@ -72,7 +72,7 @@ spec:
         - "--upstream=http://127.0.0.1:8081/"
         - "--v=10"
         - "--oidc-issuer={ISSUER}"
-        - "--oidc-clientID={CLIENT_ID}"
+        - "--oidc-required-audience={CLIENT_ID}"
         ports:
         - containerPort: 8443
           name: https


### PR DESCRIPTION
Fixes: https://github.com/brancz/kube-rbac-proxy/issues/318