### PR TITLE
allow HTTPv1 for upstream connections unconditionally

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -80,6 +80,7 @@ func NewConfig() *KubeRBACProxyConfig {
 // An empty string on `upstreamCAPath` means system cert pool will be used.
 func (i *KubeRBACProxyInfo) SetUpstreamTransport(upstreamCAPath, upstreamClientCertPath, upstreamClientKeyPath string) error {
 	transport := (http.DefaultTransport.(*http.Transport)).Clone()
+	transport.ForceAttemptHTTP2 = false
 
 	if len(upstreamCAPath) > 0 {
 		upstreamCAPEM, err := os.ReadFile(upstreamCAPath)
@@ -92,7 +93,6 @@ func (i *KubeRBACProxyInfo) SetUpstreamTransport(upstreamCAPath, upstreamClientC
 			return errors.New("error parsing upstream CA certificate")
 		}
 
-		transport.ForceAttemptHTTP2 = false
 		transport.TLSClientConfig = &tls.Config{RootCAs: upstreamCACertPool}
 	}
 
@@ -104,7 +104,6 @@ func (i *KubeRBACProxyInfo) SetUpstreamTransport(upstreamCAPath, upstreamClientC
 			return fmt.Errorf("failed to read upstream client cert/key: %w", err)
 		}
 
-		transport.ForceAttemptHTTP2 = false
 		if transport.TLSClientConfig == nil {
 			transport.TLSClientConfig = &tls.Config{}
 		}


### PR DESCRIPTION
We don't know the upstream HTTP version, there's likely no reason to force HTTP2 ever.

Fixes https://github.com/brancz/kube-rbac-proxy/issues/314