### PR TITLE
[WIP]: remove unused link, groups from userConfig in static.go

### DIFF
--- a/pkg/authorization/static/static.go
+++ b/pkg/authorization/static/static.go
@@ -38,8 +38,7 @@ type StaticAuthorizationConfig struct {
 }
 
 type UserConfig struct {
-	Name   string   `json:"name,omitempty"`
-	Groups []string `json:"groups,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 
 type staticAuthorizer struct {


### PR DESCRIPTION
this ticket to resolve issue: [(40) Not used? link #333
](https://github.com/brancz/kube-rbac-proxy/issues/333 )