### PR TITLE
cmd/krp/app,pkg/authn: make OIDC token aud agnostic

### DIFF
--- a/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
+++ b/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
@@ -189,7 +189,11 @@ func Run(cfg *server.KubeRBACProxyConfig) error {
 	var authenticator authenticator.Request
 	// If OIDC configuration provided, use oidc authenticator
 	if cfg.KubeRBACProxyInfo.OIDC.IssuerURL != "" {
-		oidcAuthenticator, err := authn.NewOIDCAuthenticator(ctx, cfg.KubeRBACProxyInfo.OIDC)
+		oidcAuthenticator, err := authn.NewOIDCAuthenticator(
+			ctx,
+			cfg.KubeRBACProxyInfo.OIDC,
+			cfg.DelegatingAuthentication.APIAudiences,
+		)
 		if err != nil {
 			return fmt.Errorf("failed to instantiate OIDC authenticator: %w", err)
 		}

--- a/pkg/authn/oidc.go
+++ b/pkg/authn/oidc.go
@@ -37,7 +37,11 @@ var (
 )
 
 // NewOIDCAuthenticator returns OIDC authenticator
-func NewOIDCAuthenticator(ctx context.Context, config *OIDCConfig) (*OIDCAuthenticator, error) {
+func NewOIDCAuthenticator(
+	ctx context.Context,
+	config *OIDCConfig,
+	auds authenticator.Audiences,
+) (*OIDCAuthenticator, error) {
 	dyCA, err := dynamiccertificates.NewDynamicCAContentFromFile("oidc-ca", config.CAFile)
 	if err != nil {
 		return nil, err
@@ -68,8 +72,13 @@ func NewOIDCAuthenticator(ctx context.Context, config *OIDCConfig) (*OIDCAuthent
 	}
 
 	return &OIDCAuthenticator{
-		dynamicClientCA:      dyCA,
-		requestAuthenticator: bearertoken.New(tokenAuthenticator),
+		dynamicClientCA: dyCA,
+		requestAuthenticator: bearertoken.New(
+			authenticator.WrapAudienceAgnosticToken(
+				auds,
+				tokenAuthenticator,
+			),
+		),
 	}, nil
 }
 


### PR DESCRIPTION
## What

Make OIDC authenticator audience agnostic.

## Why

Mo said so. And I assume the point is that the aud in an ID token will be the client ID and the overwrites the classical meaning of an "audience".