### PR TITLE
[wip] Consume rewrite parameters, except told otherwise

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ authorization:
     subresource: <string>
     name: <string>
   rewrites:
+    insecurePassthrough: <bool>
     byQueryParameter:
       name: <string>
     byHttpHeader:
@@ -160,6 +161,7 @@ The `authorization.resourceAttributes` and `authorization.rewrites` set how auth
  - `resourceAttributes` will set the given fields while sending the SAR to the kube-apiserver, while the keeping the `verb` and `user` based on the HTTP request
  - `rewrites` allows retrieving certain parameters from the incoming HTTP request and use them in the fields of `resourceAttributes` if these take the form of `{{ .Value }}`, thus allowing parametrization of the SAR sent to the kube-apiserver
 
+If `insecurePassthrough` is not set to true, the information from the HTTP request addressing the proxy for rewrites will be removed.
 
 ### How to update Go dependencies
 

--- a/pkg/authorization/rewrite/config.go
+++ b/pkg/authorization/rewrite/config.go
@@ -31,8 +31,9 @@ type RewriteAttributesConfig struct {
 // SubjectAccessReviewRewrites describes how SubjectAccessReview may be
 // rewritten on a given request.
 type SubjectAccessReviewRewrites struct {
-	ByQueryParameter *QueryParameterRewriteConfig `json:"byQueryParameter,omitempty"`
-	ByHTTPHeader     *HTTPHeaderRewriteConfig     `json:"byHttpHeader,omitempty"`
+	InsecurePassthrough bool                         `json:"insecurePassthrough,omitempty"`
+	ByQueryParameter    *QueryParameterRewriteConfig `json:"byQueryParameter,omitempty"`
+	ByHTTPHeader        *HTTPHeaderRewriteConfig     `json:"byHttpHeader,omitempty"`
 }
 
 // QueryParameterRewriteConfig describes which HTTP URL query parameter is to

--- a/pkg/authorization/rewrite/middleware.go
+++ b/pkg/authorization/rewrite/middleware.go
@@ -18,7 +18,6 @@ package rewrite
 import (
 	"context"
 	"net/http"
-	"net/textproto"
 
 	"k8s.io/apiserver/pkg/endpoints/request"
 )
@@ -56,9 +55,7 @@ func requestToParams(config *RewriteAttributesConfig, req *http.Request) []strin
 		}
 	}
 	if config.Rewrites.ByHTTPHeader != nil && config.Rewrites.ByHTTPHeader.Name != "" {
-		mimeHeader := textproto.MIMEHeader(req.Header)
-		mimeKey := textproto.CanonicalMIMEHeaderKey(config.Rewrites.ByHTTPHeader.Name)
-		if ps, ok := mimeHeader[mimeKey]; ok {
+		if ps := req.Header.Values(config.Rewrites.ByHTTPHeader.Name); len(ps) > 0 {
 			params = append(params, ps...)
 		}
 	}

--- a/pkg/authorization/rewrite/middleware_test.go
+++ b/pkg/authorization/rewrite/middleware_test.go
@@ -73,6 +73,16 @@ func TestRewriteParamsMiddleware(t *testing.T) {
 			expected: []string{"default", "other"},
 		},
 		{
+			name: "with http header rewrites config and config key is weird",
+			rewrite: &SubjectAccessReviewRewrites{
+				ByHTTPHeader: &HTTPHeaderRewriteConfig{Name: "nAmEspAcE"},
+			},
+			request: createRequest(withHeaderParameters(map[string][]string{
+				"NaMeSPaCe": {"default", "other"},
+			})),
+			expected: []string{"default", "other"},
+		},
+		{
 			name: "with http header rewrites config but missing header",
 			rewrite: &SubjectAccessReviewRewrites{
 				ByQueryParameter: &QueryParameterRewriteConfig{Name: "namespace"},


### PR DESCRIPTION
## What

If header or query params are consumed by kube-rbac-proxy, they will be cleaned up, except that the authz config states:

```
"insecurePassthrough": "true
```

## Why

If a proxy and upstream interpret parameter from the request, the probability is high that they do it differently, which invites CVEs.
In Prometheus use-cases, we want that behavior, such that if someone wants to access namespace default, a particular authorization config can created the expected SubjectAccessRequest to the apiserver.