### PR TITLE
Update outdated GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,70 +2,107 @@ name: Go
 on: [push, pull_request]
 env:
   QUAY_PATH: quay.io/brancz/kube-rbac-proxy
-  go-version: '1.23'
   kind-version: 'v0.25.0'
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.ref_name }}-go
+  cancel-in-progress: true
+
 jobs:
   check-license:
     runs-on: ubuntu-latest
     name: Check license
     steps:
-    - uses: actions/checkout@v2
-    - run: make check-license
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Check license
+      run: make check-license
+
   generate:
     runs-on: ubuntu-latest
     name: Generate
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup Golang Environment
+      uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.go-version }}
-    - run: make generate && git diff --exit-code
+        go-version: stable
+
+    - name: Generate
+      run: make generate && git diff --exit-code
+
   lint:
     runs-on: ubuntu-latest
     name: Lint
     steps:
-    - uses: actions/checkout@v2
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v2
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Lint Go
+      uses: golangci/golangci-lint-action@v6
       with:
         version: latest
         args: --timeout=5m
+
   build:
     runs-on: ubuntu-latest
     name: Build
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup Golang Environment
+      uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.go-version }}
-    - run: make build
+        go-version: stable
+
+    - name: Build
+      run: make build
+
   unit-tests:
     runs-on: ubuntu-latest
     name: Unit tests
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup Golang Environment
+      uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.go-version }}
-    - run: make test-unit
+        go-version: stable
+
+    - name: Run unit tests
+      run: make test-unit
+
   e2e-tests:
     runs-on: ubuntu-latest
     name: E2E tests
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+
+    - name: Setup Golang Environment
+      uses: actions/setup-go@v5
+      with:
+        go-version: stable
+
     - name: Start kind & create cluster
-      uses: engineerd/setup-kind@v0.5.0
+      uses: engineerd/setup-kind@v0.6.2
       with:
         version: ${{ env.kind-version }}
         config: test/e2e/kind-config/kind-config.yaml
         wait: 300s
+
     - name: Wait for cluster to finish bootstraping
       run: kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
-    - name: Setup golang for make test-e2e
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ env.go-version }}
+
     - name: Create container & run tests
       run: |
         VERSION=local VERSION_SEMVER=$(cat ./VERSION) make container
@@ -75,6 +112,7 @@ jobs:
           sleep 1
         done
         make test-e2e
+
   publish:
     runs-on: ubuntu-latest
     name: Publish container image to Quay
@@ -86,17 +124,20 @@ jobs:
     - unit-tests
     - e2e-tests
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Setup golang for building
-      uses: actions/setup-go@v2
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup Golang Environment
+      uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.go-version }}
+        go-version: stable
+
     - name: Login to Quay.io
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
+
     - name: Build images and push
       run: ./scripts/publish.sh

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,3 @@
-run:
-  skip-dirs:
+issues:
+  exclude-dirs:
     - test/


### PR DESCRIPTION
Updates the Actions to the latest version available. This among other things removes the warnings in the runs.

The `setup-go` action now accepts `stable` as a version to always use the latest stable version.

Also updated `.golangci.yaml` to remove the warnings about deprecated configuration options.