### PR TITLE
Update prometheus-example-app to v0.5.0

### DIFF
--- a/examples/non-resource-url-token-request/README.md
+++ b/examples/non-resource-url-token-request/README.md
@@ -90,7 +90,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
       - name: prometheus-example-app
-        image: quay.io/brancz/prometheus-example-app:v0.1.0
+        image: quay.io/brancz/prometheus-example-app:v0.5.0
         args:
         - "--bind=127.0.0.1:8081"
 ```

--- a/examples/non-resource-url-token-request/deployment.yaml
+++ b/examples/non-resource-url-token-request/deployment.yaml
@@ -75,6 +75,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
       - name: prometheus-example-app
-        image: quay.io/brancz/prometheus-example-app:v0.1.0
+        image: quay.io/brancz/prometheus-example-app:v0.5.0
         args:
         - "--bind=127.0.0.1:8081"

--- a/examples/non-resource-url/README.md
+++ b/examples/non-resource-url/README.md
@@ -92,7 +92,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
       - name: prometheus-example-app
-        image: quay.io/brancz/prometheus-example-app:v0.1.0
+        image: quay.io/brancz/prometheus-example-app:v0.5.0
         args:
         - "--bind=127.0.0.1:8081"
 ```

--- a/examples/non-resource-url/deployment.yaml
+++ b/examples/non-resource-url/deployment.yaml
@@ -74,6 +74,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
       - name: prometheus-example-app
-        image: quay.io/brancz/prometheus-example-app:v0.1.0
+        image: quay.io/brancz/prometheus-example-app:v0.5.0
         args:
         - "--bind=127.0.0.1:8081"

--- a/examples/oidc/deployment.yaml
+++ b/examples/oidc/deployment.yaml
@@ -79,6 +79,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
       - name: prometheus-example-app
-        image: quay.io/brancz/prometheus-example-app:v0.1.0
+        image: quay.io/brancz/prometheus-example-app:v0.5.0
         args:
         - "--bind=127.0.0.1:8081"

--- a/examples/resource-attributes/README.md
+++ b/examples/resource-attributes/README.md
@@ -110,7 +110,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
       - name: prometheus-example-app
-        image: quay.io/brancz/prometheus-example-app:v0.1.0
+        image: quay.io/brancz/prometheus-example-app:v0.5.0
         args:
         - "--bind=127.0.0.1:8081"
       volumes:

--- a/examples/resource-attributes/deployment.yaml
+++ b/examples/resource-attributes/deployment.yaml
@@ -92,7 +92,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
       - name: prometheus-example-app
-        image: quay.io/brancz/prometheus-example-app:v0.1.0
+        image: quay.io/brancz/prometheus-example-app:v0.5.0
         args:
         - "--bind=127.0.0.1:8081"
       volumes:

--- a/examples/rewrites/README.md
+++ b/examples/rewrites/README.md
@@ -112,7 +112,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
       - name: prometheus-example-app
-        image: quay.io/brancz/prometheus-example-app:v0.1.0
+        image: quay.io/brancz/prometheus-example-app:v0.5.0
         args:
         - "--bind=127.0.0.1:8081"
       volumes:

--- a/examples/rewrites/deployment.yaml
+++ b/examples/rewrites/deployment.yaml
@@ -94,7 +94,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
       - name: prometheus-example-app
-        image: quay.io/brancz/prometheus-example-app:v0.1.0
+        image: quay.io/brancz/prometheus-example-app:v0.5.0
         args:
         - "--bind=127.0.0.1:8081"
       volumes:

--- a/examples/static-auth/README.md
+++ b/examples/static-auth/README.md
@@ -116,7 +116,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
       - name: prometheus-example-app
-        image: quay.io/brancz/prometheus-example-app:v0.1.0
+        image: quay.io/brancz/prometheus-example-app:v0.5.0
         args:
         - "--bind=127.0.0.1:8081"
       volumes:

--- a/examples/static-auth/deployment.yaml
+++ b/examples/static-auth/deployment.yaml
@@ -98,7 +98,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
       - name: prometheus-example-app
-        image: quay.io/brancz/prometheus-example-app:v0.1.0
+        image: quay.io/brancz/prometheus-example-app:v0.5.0
         args:
         - "--bind=127.0.0.1:8081"
       volumes:

--- a/scripts/kind-load-local.sh
+++ b/scripts/kind-load-local.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
 kind load docker-image quay.io/brancz/kube-rbac-proxy:local
-kind load docker-image quay.io/brancz/prometheus-example-app:v0.1.0
-kind load docker-image quay.io/brancz/prometheus-example-app:v0.4.0
+kind load docker-image quay.io/brancz/prometheus-example-app:v0.5.0
 kind load docker-image quay.io/brancz/krp-curl:v0.0.2

--- a/scripts/templates/non-resource-url-deployment.yaml
+++ b/scripts/templates/non-resource-url-deployment.yaml
@@ -74,6 +74,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
       - name: prometheus-example-app
-        image: quay.io/brancz/prometheus-example-app:v0.1.0
+        image: quay.io/brancz/prometheus-example-app:v0.5.0
         args:
         - "--bind=127.0.0.1:8081"

--- a/scripts/templates/non-resource-url-token-request-deployment.yaml
+++ b/scripts/templates/non-resource-url-token-request-deployment.yaml
@@ -75,6 +75,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
       - name: prometheus-example-app
-        image: quay.io/brancz/prometheus-example-app:v0.1.0
+        image: quay.io/brancz/prometheus-example-app:v0.5.0
         args:
         - "--bind=127.0.0.1:8081"

--- a/scripts/templates/oidc-deployment.yaml
+++ b/scripts/templates/oidc-deployment.yaml
@@ -79,6 +79,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
       - name: prometheus-example-app
-        image: quay.io/brancz/prometheus-example-app:v0.1.0
+        image: quay.io/brancz/prometheus-example-app:v0.5.0
         args:
         - "--bind=127.0.0.1:8081"

--- a/scripts/templates/resource-attributes-deployment.yaml
+++ b/scripts/templates/resource-attributes-deployment.yaml
@@ -92,7 +92,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
       - name: prometheus-example-app
-        image: quay.io/brancz/prometheus-example-app:v0.1.0
+        image: quay.io/brancz/prometheus-example-app:v0.5.0
         args:
         - "--bind=127.0.0.1:8081"
       volumes:

--- a/scripts/templates/rewrites-deployment.yaml
+++ b/scripts/templates/rewrites-deployment.yaml
@@ -94,7 +94,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
       - name: prometheus-example-app
-        image: quay.io/brancz/prometheus-example-app:v0.1.0
+        image: quay.io/brancz/prometheus-example-app:v0.5.0
         args:
         - "--bind=127.0.0.1:8081"
       volumes:

--- a/test/e2e/allowpaths/deployment.yaml
+++ b/test/e2e/allowpaths/deployment.yaml
@@ -35,6 +35,6 @@ spec:
               port: 8643
               path: healthz
         - name: prometheus-example-app
-          image: quay.io/brancz/prometheus-example-app:v0.1.0
+          image: quay.io/brancz/prometheus-example-app:v0.5.0
           args:
             - "--bind=127.0.0.1:8081"

--- a/test/e2e/basics/deployment.yaml
+++ b/test/e2e/basics/deployment.yaml
@@ -26,6 +26,6 @@ spec:
             - containerPort: 8443
               name: https
         - name: prometheus-example-app
-          image: quay.io/brancz/prometheus-example-app:v0.1.0
+          image: quay.io/brancz/prometheus-example-app:v0.5.0
           args:
             - "--bind=127.0.0.1:8081"

--- a/test/e2e/clientcertificates/deployment-wrongca.yaml
+++ b/test/e2e/clientcertificates/deployment-wrongca.yaml
@@ -30,7 +30,7 @@ spec:
             - mountPath: /certs
               name: certs
         - name: prometheus-example-app
-          image: quay.io/brancz/prometheus-example-app:v0.1.0
+          image: quay.io/brancz/prometheus-example-app:v0.5.0
           args:
             - "--bind=127.0.0.1:8081"
       volumes:

--- a/test/e2e/clientcertificates/deployment.yaml
+++ b/test/e2e/clientcertificates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - mountPath: /certs
               name: certs
         - name: prometheus-example-app
-          image: quay.io/brancz/prometheus-example-app:v0.1.0
+          image: quay.io/brancz/prometheus-example-app:v0.5.0
           args:
             - "--bind=127.0.0.1:8081"
       volumes:

--- a/test/e2e/h2c-upstream/deployment-proxy-non-loopback.yaml
+++ b/test/e2e/h2c-upstream/deployment-proxy-non-loopback.yaml
@@ -27,7 +27,7 @@ spec:
             - containerPort: 8443
               name: https
         - name: prometheus-example-app
-          image: quay.io/brancz/prometheus-example-app:v0.4.0
+          image: quay.io/brancz/prometheus-example-app:v0.5.0
           args:
             - "--bind=127.0.0.1:8081"
             - "--h2c=true"

--- a/test/e2e/h2c-upstream/deployment.yaml
+++ b/test/e2e/h2c-upstream/deployment.yaml
@@ -27,7 +27,7 @@ spec:
             - containerPort: 8443
               name: https
         - name: prometheus-example-app
-          image: quay.io/brancz/prometheus-example-app:v0.4.0
+          image: quay.io/brancz/prometheus-example-app:v0.5.0
           args:
             - "--bind=127.0.0.1:8081"
             - "--h2c=true"

--- a/test/e2e/http2/deployment-no-http2.yaml
+++ b/test/e2e/http2/deployment-no-http2.yaml
@@ -28,6 +28,6 @@ spec:
             - containerPort: 8443
               name: https
         - name: prometheus-example-app
-          image: quay.io/brancz/prometheus-example-app:v0.1.0
+          image: quay.io/brancz/prometheus-example-app:v0.5.0
           args:
             - "--bind=127.0.0.1:8081"

--- a/test/e2e/http2/deployment.yaml
+++ b/test/e2e/http2/deployment.yaml
@@ -27,6 +27,6 @@ spec:
             - containerPort: 8443
               name: https
         - name: prometheus-example-app
-          image: quay.io/brancz/prometheus-example-app:v0.1.0
+          image: quay.io/brancz/prometheus-example-app:v0.5.0
           args:
             - "--bind=127.0.0.1:8081"

--- a/test/e2e/ignorepaths/deployment.yaml
+++ b/test/e2e/ignorepaths/deployment.yaml
@@ -27,6 +27,6 @@ spec:
             - containerPort: 8443
               name: https
         - name: prometheus-example-app
-          image: quay.io/brancz/prometheus-example-app:v0.1.0
+          image: quay.io/brancz/prometheus-example-app:v0.5.0
           args:
             - "--bind=127.0.0.1:8081"

--- a/test/e2e/static-auth/deployment.yaml
+++ b/test/e2e/static-auth/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
         - name: prometheus-example-app
-          image: quay.io/brancz/prometheus-example-app:v0.1.0
+          image: quay.io/brancz/prometheus-example-app:v0.5.0
           args:
             - "--bind=127.0.0.1:8081"
       volumes:

--- a/test/e2e/tokenrequest/deployment.yaml
+++ b/test/e2e/tokenrequest/deployment.yaml
@@ -27,6 +27,6 @@ spec:
             - containerPort: 8443
               name: https
         - name: prometheus-example-app
-          image: quay.io/brancz/prometheus-example-app:v0.1.0
+          image: quay.io/brancz/prometheus-example-app:v0.5.0
           args:
             - "--bind=127.0.0.1:8081"


### PR DESCRIPTION
Cherry pick from master, original desc below:

---
v0.1.0 doesn't work by default, at least in minikube. It fails with this error:
Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release

Pulling 0.5.0 works as expected, so running examples should work out of the box.