### PR TITLE
fix ARGs in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 ARG GOARCH=amd64
-ARG GOOS=linux
+
 ARG BASEIMAGE=gcr.io/distroless/static:nonroot-$GOARCH
 FROM $BASEIMAGE
 
+ARG GOARCH
+ARG GOOS=linux
 ARG BINARY=kube-rbac-proxy-$GOOS-$GOARCH
 COPY _output/$BINARY /usr/local/bin/kube-rbac-proxy
 EXPOSE 8080


### PR DESCRIPTION
Define ARGs in a global scope of a Dockerfile does not inherit to stages.

Ref: https://docs.docker.com/build/building/variables/#scoping

