### PR TITLE
.github/workflows: add govulncheck GitHub Action on Mondays

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,25 @@
+name: Security - Go Vulnerability Check
+on:
+  schedule:
+  - cron: '0 4 * * 1' # Every Monday at 4:00 AM UTC
+  workflow_dispatch: # Allow manual trigger
+env:
+  go-version: '1.25'
+jobs:
+  govulncheck:
+    name: Check Go vulnerabilities
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - name: Set up Go
+      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+      with:
+        go-version: ${{ env.go-version }}
+    - name: Run govulncheck
+      uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+      with:
+        go-version-input: ${{ env.go-version }}
+        go-package: ./...
+


### PR DESCRIPTION
## What

Make govulncheck run on Mondays

## Why

I want to have a report at hand that should trigger all alarm bells, not like trivy and grype.

## Notes

I hope this works.