### PR TITLE
test/e2e: show example of how to RBAC CRUD on phantom-resource

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -49,6 +49,7 @@ func Test(t *testing.T) {
 		"HTTP2":              testHTTP2(client),
 		"Flags":              testFlags(client),
 		"TokenMasking":       testTokenMasking(client),
+		"PhantomResource":    testPhantomResource(client),
 	}
 
 	for name, tc := range tests {

--- a/test/e2e/phantom-resource/clusterRole-client.yaml
+++ b/test/e2e/phantom-resource/clusterRole-client.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: phantom-resource-access
+rules:
+  - apiGroups: ["ai.example.com"]
+    resources: ["aicapabilities"]
+    verbs: ["get", "create", "update", "patch", "delete"]

--- a/test/e2e/phantom-resource/clusterRole.yaml
+++ b/test/e2e/phantom-resource/clusterRole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-rbac-proxy
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources:
+      - tokenreviews
+    verbs: ["create"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources:
+      - subjectaccessreviews
+    verbs: ["create"]

--- a/test/e2e/phantom-resource/clusterRoleBinding-client.yaml
+++ b/test/e2e/phantom-resource/clusterRoleBinding-client.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: phantom-resource-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: phantom-resource-access
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: default

--- a/test/e2e/phantom-resource/clusterRoleBinding.yaml
+++ b/test/e2e/phantom-resource/clusterRoleBinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-rbac-proxy
+subjects:
+  - kind: ServiceAccount
+    name: kube-rbac-proxy
+    namespace: default

--- a/test/e2e/phantom-resource/configmap.yaml
+++ b/test/e2e/phantom-resource/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-rbac-proxy
+  namespace: default
+data:
+  config-file.yaml: |+
+    authorization:
+      resourceAttributes:
+        namespace: default
+        apiGroup: ai.example.com
+        apiVersion: v1
+        resource: aicapabilities

--- a/test/e2e/phantom-resource/deployment.yaml
+++ b/test/e2e/phantom-resource/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-rbac-proxy
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-rbac-proxy
+  template:
+    metadata:
+      labels:
+        app: kube-rbac-proxy
+    spec:
+      serviceAccountName: kube-rbac-proxy
+      containers:
+        - name: kube-rbac-proxy
+          image: quay.io/brancz/kube-rbac-proxy:local
+          args:
+            - "--secure-listen-address=0.0.0.0:8443"
+            - "--upstream=http://127.0.0.1:8081/"
+            - "--config-file=/etc/kube-rbac-proxy/config-file.yaml"
+            - "--v=10"
+          ports:
+            - containerPort: 8443
+              name: https
+          volumeMounts:
+            - name: config
+              mountPath: /etc/kube-rbac-proxy
+        - name: nginx
+          image: nginx:alpine
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              cat > /etc/nginx/nginx.conf <<EOF
+              events {}
+              http {
+                server {
+                  listen 8081;
+                  location / {
+                    return 200 'Method: \$request_method\n';
+                    add_header Content-Type text/plain;
+                  }
+                }
+              }
+              EOF
+              nginx -g 'daemon off;'
+      volumes:
+        - name: config
+          configMap:
+            name: kube-rbac-proxy

--- a/test/e2e/phantom-resource/service.yaml
+++ b/test/e2e/phantom-resource/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-rbac-proxy
+  name: kube-rbac-proxy
+  namespace: default
+spec:
+  ports:
+    - name: https
+      port: 8443
+      targetPort: https
+  selector:
+    app: kube-rbac-proxy

--- a/test/e2e/phantom-resource/serviceAccount.yaml
+++ b/test/e2e/phantom-resource/serviceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-rbac-proxy
+  namespace: default

--- a/test/e2e/phantom_resource.go
+++ b/test/e2e/phantom_resource.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2025 the kube-rbac-proxy maintainers All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"net/http"
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/brancz/kube-rbac-proxy/test/kubetest"
+)
+
+type curlRequest struct {
+	method string
+	url    string
+}
+
+func newDefaultRequest() curlRequest {
+	return curlRequest{
+		method: "GET",
+		url:    "https://kube-rbac-proxy.default.svc.cluster.local:8443/",
+	}
+}
+
+func (c curlRequest) WithMethod(method string) curlRequest {
+	c.method = method
+	return c
+}
+
+func (c curlRequest) Build() string {
+	authHeader := `-H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"`
+	methodFlag := ""
+	if c.method != "" && c.method != "GET" {
+		methodFlag = "-X " + c.method + " "
+	}
+	return `curl --connect-timeout 5 -v -s -k --fail ` + methodFlag + authHeader + ` ` + c.url
+}
+
+func testPhantomResource(client kubernetes.Interface) kubetest.TestSuite {
+	return func(t *testing.T) {
+		baseManifests := []string{
+			"phantom-resource/clusterRole.yaml",
+			"phantom-resource/clusterRoleBinding.yaml",
+			"phantom-resource/configmap.yaml",
+			"phantom-resource/deployment.yaml",
+			"phantom-resource/service.yaml",
+			"phantom-resource/serviceAccount.yaml",
+		}
+
+		rbacManifests := append(baseManifests,
+			"phantom-resource/clusterRole-client.yaml",
+			"phantom-resource/clusterRoleBinding-client.yaml",
+		)
+
+		testCases := []string{
+			http.MethodGet, http.MethodPost,
+		}
+
+		kubetest.Scenario{
+			Name: "PhantomResourceNoRBAC",
+			Description: `
+				As a client without RBAC rules for a phantom resource,
+				I fail with my request even though the resource doesn't exist
+			`,
+			Given: kubetest.Actions(
+				kubetest.CreatedManifests(client, baseManifests...),
+			),
+			When: kubetest.Actions(
+				kubetest.PodsAreReady(client, 1, "app=kube-rbac-proxy"),
+				kubetest.ServiceIsReady(client, "kube-rbac-proxy"),
+			),
+			Then: kubetest.Actions(
+				kubetest.ClientFails(
+					client,
+					newDefaultRequest().Build(),
+					nil,
+				),
+			),
+		}.Run(t)
+
+		for _, method := range testCases {
+			kubetest.Scenario{
+				Name: "PhantomResourceCRUD/" + method,
+				Given: kubetest.Actions(
+					kubetest.CreatedManifests(client, rbacManifests...),
+				),
+				When: kubetest.Actions(
+					kubetest.PodsAreReady(client, 1, "app=kube-rbac-proxy"),
+					kubetest.ServiceIsReady(client, "kube-rbac-proxy"),
+				),
+				Then: kubetest.Actions(
+					kubetest.ClientSucceeds(
+						client,
+						newDefaultRequest().WithMethod(method).Build(),
+						nil,
+					),
+				),
+			}.Run(t)
+		}
+	}
+}


### PR DESCRIPTION
## What

Shows how you can safely give full CRUD RBAC to fake resource.

## Why

To show that you don't need to bind the RBAC of a user to a real k8s resource and indirectly alllowing that user to do CRUD on that resource.

E.g. malicious user of upstream, with kube-rbac-proxy configured to check user/post RBAC against resource X specified in ResourceAttributes, can create unlimited amount of resource X