### PR TITLE
fix: bump go version to fix CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brancz/kube-rbac-proxy
 
-go 1.24.6
+go 1.24.9
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
bump go version to at least `1.24.8` to fix CVEs

```bash
❯ grype reg.echohq.com/kubebuilder-kube-rbac-proxy:v0.20.0-mini

NAME    INSTALLED  FIXED IN        TYPE       VULNERABILITY   SEVERITY  EPSS           RISK
stdlib  go1.25.1   1.24.8, 1.25.2  go-module  CVE-2025-61723  High      < 0.1% (21st)  < 0.1
stdlib  go1.25.1   1.24.8, 1.25.2  go-module  CVE-2025-61725  High      < 0.1% (21st)  < 0.1
stdlib  go1.25.1   1.24.8, 1.25.2  go-module  CVE-2025-58186  Medium    < 0.1% (15th)  < 0.1
stdlib  go1.25.1   1.24.8, 1.25.2  go-module  CVE-2025-61724  Medium    < 0.1% (15th)  < 0.1
stdlib  go1.25.1   1.24.8, 1.25.2  go-module  CVE-2025-47912  Medium    < 0.1% (15th)  < 0.1
stdlib  go1.25.1   1.24.8, 1.25.2  go-module  CVE-2025-58188  High      < 0.1% (7th)   < 0.1
stdlib  go1.25.1   1.24.8, 1.25.2  go-module  CVE-2025-58189  Medium    < 0.1% (10th)  < 0.1
stdlib  go1.25.1   1.24.8, 1.25.2  go-module  CVE-2025-58185  Medium    < 0.1% (5th)   < 0.1
stdlib  go1.25.1   1.24.9, 1.25.3  go-module  CVE-2025-58187  High      < 0.1% (2nd)   < 0.1
stdlib  go1.25.1   1.24.8, 1.25.2  go-module  CVE-2025-58183  Medium    < 0.1% (2nd)   < 0.1
```