### PR TITLE
Add unix domain socket support

### DIFF
--- a/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
+++ b/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
@@ -130,9 +130,11 @@ type completedProxyRunOptions struct {
 	secureListenAddress   string
 	proxyEndpointsPort    int
 
-	upstreamURL      *url.URL
-	upstreamForceH2C bool
-	upstreamCABundle *x509.CertPool
+	upstreamURL        *url.URL
+	upstreamForceH2C   bool
+	upstreamCABundle   *x509.CertPool
+	upstreamSocketPath string
+	upstreamHTTPPath   string
 
 	http2Disable bool
 	http2Options *http2.Server
@@ -158,9 +160,21 @@ func Complete(o *options.ProxyRunOptions) (*completedProxyRunOptions, error) {
 		ignorePaths: o.IgnorePaths,
 	}
 
-	completed.upstreamURL, err = url.Parse(o.Upstream)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse upstream URL: %w", err)
+	if strings.HasPrefix(o.Upstream, "unix://") {
+		socketPath, httpPath := options.ParseUnixUpstream(o.Upstream)
+		completed.upstreamSocketPath = socketPath
+		completed.upstreamHTTPPath = httpPath
+		// Use root path for the target URL; the httpPath is applied
+		// by the Director to avoid double-joining with the request path.
+		completed.upstreamURL, err = url.Parse("http://unix/")
+		if err != nil {
+			return nil, fmt.Errorf("failed to construct upstream URL for unix socket: %w", err)
+		}
+	} else {
+		completed.upstreamURL, err = url.Parse(o.Upstream)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse upstream URL: %w", err)
+		}
 	}
 
 	if upstreamCAPath := o.UpstreamCAFile; len(upstreamCAPath) > 0 {
@@ -259,13 +273,31 @@ func Run(cfg *completedProxyRunOptions) error {
 		sarAuthorizer,
 	)
 
-	upstreamTransport, err := initTransport(cfg.upstreamCABundle, cfg.tls.UpstreamClientCertFile, cfg.tls.UpstreamClientKeyFile)
-	if err != nil {
-		return fmt.Errorf("failed to set up upstream TLS connection: %w", err)
+	var upstreamTransport http.RoundTripper
+	if cfg.upstreamSocketPath != "" {
+		upstreamTransport = initUnixTransport(cfg.upstreamSocketPath)
+	} else {
+		var err2 error
+		upstreamTransport, err2 = initTransport(cfg.upstreamCABundle, cfg.tls.UpstreamClientCertFile, cfg.tls.UpstreamClientKeyFile)
+		if err2 != nil {
+			return fmt.Errorf("failed to set up upstream TLS connection: %w", err2)
+		}
 	}
 
 	proxy := httputil.NewSingleHostReverseProxy(cfg.upstreamURL)
 	proxy.Transport = upstreamTransport
+
+	// When an explicit http-path is configured for a unix socket upstream,
+	// override the request path so it is sent to the upstream as-is rather
+	// than being joined with the client's request path.
+	if cfg.upstreamHTTPPath != "" && cfg.upstreamHTTPPath != "/" {
+		defaultDirector := proxy.Director
+		proxy.Director = func(req *http.Request) {
+			defaultDirector(req)
+			req.URL.Path = cfg.upstreamHTTPPath
+			req.URL.RawPath = ""
+		}
+	}
 
 	if cfg.upstreamForceH2C {
 		// Force http/2 for connections to the upstream i.e. do not start with HTTP1.1 UPGRADE req to

--- a/cmd/kube-rbac-proxy/app/options/options.go
+++ b/cmd/kube-rbac-proxy/app/options/options.go
@@ -19,6 +19,7 @@ package options
 import (
 	"fmt"
 	"path"
+	"strings"
 	"time"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -195,10 +196,43 @@ For more information, please go to https://github.com/brancz/kube-rbac-proxy/iss
 		}
 	}
 
+	if strings.HasPrefix(o.Upstream, "unix://") {
+		socketPath, _ := ParseUnixUpstream(o.Upstream)
+		if !path.IsAbs(socketPath) || socketPath == "" {
+			errs = append(errs, fmt.Errorf("unix upstream socket path must be absolute, got %q", socketPath))
+		}
+		if o.UpstreamForceH2C {
+			errs = append(errs, fmt.Errorf("--upstream-force-h2c cannot be used with unix:// upstream"))
+		}
+		if o.UpstreamCAFile != "" {
+			errs = append(errs, fmt.Errorf("--upstream-ca-file cannot be used with unix:// upstream"))
+		}
+		if o.TLS.UpstreamClientCertFile != "" || o.TLS.UpstreamClientKeyFile != "" {
+			errs = append(errs, fmt.Errorf("--upstream-client-cert-file and --upstream-client-key-file cannot be used with unix:// upstream"))
+		}
+	}
+
 	// Removed upstream flags shouldn't be use
 	if err := o.validateDisabledFlags(); err != nil {
 		errs = append(errs, err)
 	}
 
 	return utilerrors.NewAggregate(errs)
+}
+
+// ParseUnixUpstream parses a unix:// upstream string into socket path and HTTP path.
+// Format: unix://<socket-path> or unix://<socket-path>:<http-path>
+func ParseUnixUpstream(upstream string) (socketPath, httpPath string) {
+	raw := strings.TrimPrefix(upstream, "unix://")
+	if idx := strings.LastIndex(raw, ":"); idx != -1 {
+		socketPath = raw[:idx]
+		httpPath = raw[idx+1:]
+	} else {
+		socketPath = raw
+		httpPath = "/"
+	}
+	if httpPath == "" {
+		httpPath = "/"
+	}
+	return socketPath, httpPath
 }

--- a/cmd/kube-rbac-proxy/app/options/options_test.go
+++ b/cmd/kube-rbac-proxy/app/options/options_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2024 the kube-rbac-proxy maintainers. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseUnixUpstream(t *testing.T) {
+	tests := []struct {
+		name           string
+		upstream       string
+		wantSocketPath string
+		wantHTTPPath   string
+	}{
+		{
+			name:           "socket path only",
+			upstream:       "unix:///var/run/app.sock",
+			wantSocketPath: "/var/run/app.sock",
+			wantHTTPPath:   "/",
+		},
+		{
+			name:           "socket path with http path",
+			upstream:       "unix:///var/run/app.sock:/metrics",
+			wantSocketPath: "/var/run/app.sock",
+			wantHTTPPath:   "/metrics",
+		},
+		{
+			name:           "socket path with nested http path",
+			upstream:       "unix:///var/run/app.sock:/api/v1/metrics",
+			wantSocketPath: "/var/run/app.sock",
+			wantHTTPPath:   "/api/v1/metrics",
+		},
+		{
+			name:           "socket path with empty http path uses default",
+			upstream:       "unix:///var/run/app.sock:",
+			wantSocketPath: "/var/run/app.sock",
+			wantHTTPPath:   "/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			socketPath, httpPath := ParseUnixUpstream(tt.upstream)
+			if socketPath != tt.wantSocketPath {
+				t.Errorf("socketPath = %q, want %q", socketPath, tt.wantSocketPath)
+			}
+			if httpPath != tt.wantHTTPPath {
+				t.Errorf("httpPath = %q, want %q", httpPath, tt.wantHTTPPath)
+			}
+		})
+	}
+}
+
+func TestValidateUnixUpstream(t *testing.T) {
+	tests := []struct {
+		name      string
+		modify    func(o *ProxyRunOptions)
+		wantErr   string
+		wantNoErr bool
+	}{
+		{
+			name: "valid unix upstream",
+			modify: func(o *ProxyRunOptions) {
+				o.Upstream = "unix:///var/run/app.sock"
+			},
+			wantNoErr: true,
+		},
+		{
+			name: "relative socket path rejected",
+			modify: func(o *ProxyRunOptions) {
+				o.Upstream = "unix://relative/path.sock"
+			},
+			wantErr: "must be absolute",
+		},
+		{
+			name: "upstream-force-h2c rejected with unix",
+			modify: func(o *ProxyRunOptions) {
+				o.Upstream = "unix:///var/run/app.sock"
+				o.UpstreamForceH2C = true
+			},
+			wantErr: "--upstream-force-h2c cannot be used",
+		},
+		{
+			name: "upstream-ca-file rejected with unix",
+			modify: func(o *ProxyRunOptions) {
+				o.Upstream = "unix:///var/run/app.sock"
+				o.UpstreamCAFile = "/some/ca.pem"
+			},
+			wantErr: "--upstream-ca-file cannot be used",
+		},
+		{
+			name: "upstream client cert rejected with unix",
+			modify: func(o *ProxyRunOptions) {
+				o.Upstream = "unix:///var/run/app.sock"
+				o.TLS.UpstreamClientCertFile = "/some/cert.pem"
+			},
+			wantErr: "--upstream-client-cert-file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := NewProxyRunOptions()
+			// Initialize flagSet by calling Flags(), required by validateDisabledFlags
+			o.Flags()
+			// Set required defaults to avoid unrelated validation noise
+			o.TLS.CertFile = "cert.pem"
+			o.TLS.KeyFile = "key.pem"
+			o.SecureListenAddress = ":8443"
+			tt.modify(o)
+
+			err := o.Validate()
+			if tt.wantNoErr {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("expected error containing %q, got: %v", tt.wantErr, err)
+			}
+		})
+	}
+}

--- a/cmd/kube-rbac-proxy/app/transport.go
+++ b/cmd/kube-rbac-proxy/app/transport.go
@@ -17,6 +17,7 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -61,4 +62,18 @@ func initTransport(upstreamCAPool *x509.CertPool, upstreamClientCertPath, upstre
 	}
 
 	return transport, nil
+}
+
+func initUnixTransport(socketPath string) http.RoundTripper {
+	return &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext(ctx, "unix", socketPath)
+		},
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
 }

--- a/cmd/kube-rbac-proxy/app/transport_test.go
+++ b/cmd/kube-rbac-proxy/app/transport_test.go
@@ -158,6 +158,51 @@ func TestInitTransportWithClientCertAuth(t *testing.T) {
 	}
 }
 
+func TestInitUnixTransport(t *testing.T) {
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "test.sock")
+
+	// Start a server on the unix socket
+	l, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("failed to listen on unix socket: %v", err)
+	}
+	defer l.Close()
+
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("hello from unix socket"))
+		}),
+	}
+	go func() {
+		_ = srv.Serve(l)
+	}()
+	defer srv.Close()
+
+	transport := initUnixTransport(socketPath)
+
+	// The host in the URL is irrelevant; the transport dials the socket directly
+	req, err := http.NewRequest(http.MethodGet, "http://unix/test", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+
+	if string(body) != "hello from unix socket" {
+		t.Errorf("unexpected response body: %s", body)
+	}
+}
+
 func generateClientCert(t *testing.T) ([]byte, []byte, *x509.CertPool, error) {
 	t.Helper()
 

--- a/examples/unix-domain-socket/README.md
+++ b/examples/unix-domain-socket/README.md
@@ -1,0 +1,51 @@
+# Unix Domain Socket Upstream Example
+
+This example demonstrates how to use kube-rbac-proxy with an upstream application that listens on a Unix domain socket instead of a TCP port.
+
+Using a Unix domain socket for the upstream connection provides several benefits:
+
+- **No port conflicts** — the upstream doesn't need to bind a TCP port in the pod.
+- **Filesystem-level access control** — socket permissions limit which processes can connect.
+- **No network exposure** — the upstream is never reachable over TCP, even on localhost.
+
+## How it works
+
+Both containers in the pod share an `emptyDir` volume mounted at `/sockets`. The upstream application creates its socket at `/sockets/app.sock`, and kube-rbac-proxy connects to it using the `unix://` scheme:
+
+```
+--upstream=unix:///sockets/app.sock
+```
+
+The format is `unix://<socket-path>` or `unix://<socket-path>:<http-path-prefix>`. The `:<http-path-prefix>` portion is optional and defaults to `/`.
+
+## Deploy
+
+```bash
+kubectl create -f deployment.yaml
+```
+
+The deployment creates:
+
+- A `ServiceAccount` and RBAC for kube-rbac-proxy to perform TokenReviews and SubjectAccessReviews.
+- A `Service` exposing port 8443.
+- A `Deployment` with two containers sharing the socket volume:
+  - **kube-rbac-proxy** — listens on `0.0.0.0:8443` (TLS), proxies authenticated requests to the unix socket.
+  - **upstream** — a simple app that listens on `unix:///sockets/app.sock` and serves Prometheus metrics at `/metrics`.
+
+The upstream app source is in the `upstream/` directory.
+
+## Test
+
+Grant the default service account access to `/metrics`, then run a curl job:
+
+```bash
+kubectl create -f client-rbac.yaml -f client.yaml
+```
+
+Check the logs:
+
+```bash
+kubectl logs job/krp-curl
+```
+
+You should see a successful 200 response with Prometheus metrics from the upstream app.

--- a/examples/unix-domain-socket/client-rbac.yaml
+++ b/examples/unix-domain-socket/client-rbac.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metrics
+rules:
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metrics
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: default

--- a/examples/unix-domain-socket/client.yaml
+++ b/examples/unix-domain-socket/client.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: krp-curl
+spec:
+  template:
+    metadata:
+      name: krp-curl
+    spec:
+      containers:
+      - name: krp-curl
+        image: quay.io/brancz/krp-curl:v0.0.2
+      restartPolicy: Never
+  backoffLimit: 4

--- a/examples/unix-domain-socket/deployment.yaml
+++ b/examples/unix-domain-socket/deployment.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-rbac-proxy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: kube-rbac-proxy
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-rbac-proxy
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+  - subjectaccessreviews
+  verbs: ["create"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-rbac-proxy
+  name: kube-rbac-proxy
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    app: kube-rbac-proxy
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-rbac-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-rbac-proxy
+  template:
+    metadata:
+      labels:
+        app: kube-rbac-proxy
+    spec:
+      serviceAccountName: kube-rbac-proxy
+      containers:
+      - name: kube-rbac-proxy
+        image: localhost/kube-rbac-proxy:local
+        imagePullPolicy: IfNotPresent
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=unix:///sockets/app.sock:/metrics"
+        - "--v=10"
+        ports:
+        - containerPort: 8443
+          name: https
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - name: socket
+          mountPath: /sockets
+      - name: upstream
+        image: localhost/unix-upstream:local
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - name: socket
+          mountPath: /sockets
+      volumes:
+      - name: socket
+        emptyDir: {}

--- a/examples/unix-domain-socket/upstream/Dockerfile
+++ b/examples/unix-domain-socket/upstream/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.23 AS builder
+WORKDIR /app
+COPY main.go .
+RUN CGO_ENABLED=0 go build -o unix-upstream main.go
+
+FROM gcr.io/distroless/static:nonroot-amd64
+COPY --from=builder /app/unix-upstream /usr/local/bin/unix-upstream
+USER 65532:65532
+ENTRYPOINT ["/usr/local/bin/unix-upstream"]

--- a/examples/unix-domain-socket/upstream/main.go
+++ b/examples/unix-domain-socket/upstream/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+)
+
+func main() {
+	socketPath := "/sockets/app.sock"
+	if p := os.Getenv("SOCKET_PATH"); p != "" {
+		socketPath = p
+	}
+
+	// Clean up stale socket file
+	os.Remove(socketPath)
+
+	l, err := net.Listen("unix", socketPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to listen on %s: %v\n", socketPath, err)
+		os.Exit(1)
+	}
+	defer l.Close()
+
+	// Make the socket accessible by other users in the pod
+	if err := os.Chmod(socketPath, 0666); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to chmod socket: %v\n", err)
+		os.Exit(1)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		fmt.Fprintln(w, "# HELP version Version information about this binary")
+		fmt.Fprintln(w, "# TYPE version gauge")
+		fmt.Fprintln(w, `version{version="v0.1.0"} 0`)
+	})
+
+	fmt.Printf("listening on unix socket %s\n", socketPath)
+	if err := http.Serve(l, mux); err != nil {
+		fmt.Fprintf(os.Stderr, "server error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -49,6 +49,7 @@ func Test(t *testing.T) {
 		"HTTP2":              testHTTP2(client),
 		"Flags":              testFlags(client),
 		"TokenMasking":       testTokenMasking(client),
+		"UnixDomainSocket":   testUnixDomainSocket(client),
 	}
 
 	for name, tc := range tests {

--- a/test/e2e/unix_domain_socket.go
+++ b/test/e2e/unix_domain_socket.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2026 the kube-rbac-proxy maintainers. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/brancz/kube-rbac-proxy/test/kubetest"
+)
+
+func testUnixDomainSocket(client kubernetes.Interface) kubetest.TestSuite {
+	return func(t *testing.T) {
+		command := `curl --connect-timeout 5 -v -s -k --fail -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" https://kube-rbac-proxy.default.svc.cluster.local:8443/metrics`
+
+		unixUpstreamContainer := &corev1.Container{
+			Name:  "unix-upstream",
+			Image: "quay.io/brancz/unix-upstream:local",
+		}
+
+		unixSocketConfig := func() *kubetest.KRPTestConfig {
+			return kubetest.NewBasicKubeRBACProxyTestConfig().
+				UpdateFlags(map[string]string{
+					"upstream": "unix:///sockets/app.sock",
+				}).
+				ReplaceUpstream(unixUpstreamContainer).
+				WithEmptyDirVolume("sockets", "/sockets", 0, 1)
+		}
+
+		kubetest.Scenario{
+			Name: "WithRBAC",
+			Description: `
+				As a client with the correct RBAC rules proxying through
+				a unix domain socket upstream, I succeed with my request
+			`,
+
+			Given: kubetest.Actions(
+				unixSocketConfig().Launch(client),
+			),
+			When: kubetest.Actions(
+				kubetest.PodsAreReady(
+					client,
+					1,
+					"app=kube-rbac-proxy",
+				),
+				kubetest.ServiceIsReady(
+					client,
+					"kube-rbac-proxy",
+				),
+			),
+			Then: kubetest.Actions(
+				kubetest.ClientSucceeds(
+					client,
+					command,
+					nil,
+				),
+			),
+		}.Run(t)
+
+		kubetest.Scenario{
+			Name: "NoRBAC",
+			Description: `
+				As a client without RBAC rules proxying through
+				a unix domain socket upstream, I fail with my request
+			`,
+
+			Given: kubetest.Actions(
+				unixSocketConfig().
+					WithoutMetricsEndpointAllowClusterRole().
+					Launch(client),
+			),
+			When: kubetest.Actions(
+				kubetest.PodsAreReady(
+					client,
+					1,
+					"app=kube-rbac-proxy",
+				),
+				kubetest.ServiceIsReady(
+					client,
+					"kube-rbac-proxy",
+				),
+			),
+			Then: kubetest.Actions(
+				kubetest.ClientFails(
+					client,
+					command,
+					nil,
+				),
+			),
+		}.Run(t)
+
+		kubetest.Scenario{
+			Name: "WithHTTPPath",
+			Description: `
+				As a client with the correct RBAC rules proxying through
+				a unix domain socket upstream with an explicit http path,
+				I succeed with my request
+			`,
+
+			Given: kubetest.Actions(
+				kubetest.NewBasicKubeRBACProxyTestConfig().
+					UpdateFlags(map[string]string{
+						"upstream": "unix:///sockets/app.sock:/metrics",
+					}).
+					ReplaceUpstream(unixUpstreamContainer).
+					WithEmptyDirVolume("sockets", "/sockets", 0, 1).
+					Launch(client),
+			),
+			When: kubetest.Actions(
+				kubetest.PodsAreReady(
+					client,
+					1,
+					"app=kube-rbac-proxy",
+				),
+				kubetest.ServiceIsReady(
+					client,
+					"kube-rbac-proxy",
+				),
+			),
+			Then: kubetest.Actions(
+				kubetest.ClientSucceeds(
+					client,
+					command,
+					nil,
+				),
+			),
+		}.Run(t)
+	}
+}

--- a/test/kubetest/config.go
+++ b/test/kubetest/config.go
@@ -35,6 +35,13 @@ import (
 	"github.com/brancz/kube-rbac-proxy/test/kubetest/testtemplates"
 )
 
+// EmptyDirVolume describes an emptyDir volume to be shared between containers.
+type EmptyDirVolume struct {
+	Name       string
+	MountPath  string
+	Containers []int // indices of containers to mount into (e.g., []int{0, 1})
+}
+
 type KRPTestConfig struct {
 	Flags               map[string]string
 	UpstreamFlags       map[string]string
@@ -42,6 +49,7 @@ type KRPTestConfig struct {
 
 	MountedSecrets          map[string]*corev1.Secret      // mounts to /var/run/secrets/<key>
 	MountedConfigMaps       map[string]*corev1.ConfigMap   // mounts to /var/run/configMaps/<key>
+	EmptyDirVolumes         []EmptyDirVolume               // emptyDir volumes shared between containers
 	SAClusterRoleBindings   map[string]*rbacv1.ClusterRole // maps local SA name to ClusterRole
 	UserClusterRoleBindings map[string]*rbacv1.ClusterRole // maps user name to ClusterRole
 
@@ -141,6 +149,15 @@ func (c *KRPTestConfig) WithServerCerts(hostBase string) *KRPTestConfig {
 	return c
 }
 
+func (c *KRPTestConfig) WithEmptyDirVolume(name, mountPath string, containers ...int) *KRPTestConfig {
+	c.EmptyDirVolumes = append(c.EmptyDirVolumes, EmptyDirVolume{
+		Name:       name,
+		MountPath:  mountPath,
+		Containers: containers,
+	})
+	return c
+}
+
 func (c *KRPTestConfig) ReplaceUpstream(upstream *corev1.Container) *KRPTestConfig {
 	c.UpstreamReplacement = upstream
 	return c
@@ -204,6 +221,25 @@ func (c *KRPTestConfig) Launch(client kubernetes.Interface) Action {
 				return err
 			}
 			ctx.CleanUp = append(ctx.CleanUp, cmCleanup)
+		}
+
+		for _, edv := range c.EmptyDirVolumes {
+			podSpec := &finalDeployment.Spec.Template.Spec
+			podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+				Name: edv.Name,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			})
+			for _, idx := range edv.Containers {
+				podSpec.Containers[idx].VolumeMounts = append(
+					podSpec.Containers[idx].VolumeMounts,
+					corev1.VolumeMount{
+						Name:      edv.Name,
+						MountPath: edv.MountPath,
+					},
+				)
+			}
 		}
 
 		// the service account name is currently hardcoded in the KRP deployment template


### PR DESCRIPTION
## Summary

  - Adds unix:// scheme support for --upstream, allowing kube-rbac-proxy to connect to upstream services over Unix domain sockets
  - Format: unix:///path/to/socket or unix:///path/to/socket:/http-path
  - Shared emptyDir volumes enable sidecar communication without exposing TCP ports

## Motivation

  Unix domain sockets avoid localhost port conflicts, eliminate network exposure of the upstream, and leverage filesystem permissions for access control.

## Changes

  - Parse unix:// upstream URLs into socket path and optional HTTP path
  - Custom http.Transport with DialContext targeting the socket
  - Validation rejects incompatible flags (--upstream-force-h2c, --upstream-ca-file, --upstream-client-cert-file)
  - Example deployment with a simple upstream app in examples/unix-domain-socket/
  - Unit tests for parsing, validation, and transport

Fixes #199 
Generated by Claude
Manually tested on Kind and reviewed by @rphillips 