### PR TITLE
pkg/proxy: fix attributes logging

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -62,7 +62,7 @@ func (n krpAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *http
 	var allAttrs []authorizer.Attributes
 
 	defer func() {
-		for attrs := range allAttrs {
+		for _, attrs := range allAttrs {
 			klog.V(5).Infof("kube-rbac-proxy request attributes: attrs=%#+v", attrs)
 		}
 	}()


### PR DESCRIPTION
## What

log attributes not index.

## Why

There is no value in index logging.